### PR TITLE
feat: 장소 조회수 증가, 조회 및 핫플레이스 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/SejongLifeBeApplication.java
+++ b/src/main/java/org/example/sejonglifebe/SejongLifeBeApplication.java
@@ -3,7 +3,9 @@ package org.example.sejonglifebe;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class SejongLifeBeApplication {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.common.dto.ApiResponse;
+import org.example.sejonglifebe.place.dto.HotPlaceResponse;
 import org.springframework.http.HttpStatus;
 
 import java.util.List;
@@ -34,13 +35,19 @@ public class PlaceController {
         return ApiResponse.of(HttpStatus.OK, "장소 목록 조회 성공", response);
     }
 
+    @GetMapping("/hot")
+    public ResponseEntity<ApiResponse<List<HotPlaceResponse>>> getHotPlaces() {
+        List<HotPlaceResponse> hotPlaceResponses = placeService.getWeeklyHotPlaces();
+        return ApiResponse.of(HttpStatus.OK, "핫플레이스 조회 성공", hotPlaceResponses);
+    }
+
     @GetMapping("/{placeId}")
     public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long placeId,
                                                                            HttpServletRequest request,
                                                                            HttpServletResponse response)
     {
         PlaceDetailResponse placeDetailResponse =
-                placeService.getPlaceDetail(placeId, request, response);;
+                placeService.getPlaceDetail(placeId, request, response);
         return ApiResponse.of(HttpStatus.OK, "장소 상세 정보 조회 성공", placeDetailResponse);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.place;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.common.dto.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -33,9 +35,13 @@ public class PlaceController {
     }
 
     @GetMapping("/{placeId}")
-    public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable("placeId") Long placeId) {
-        PlaceDetailResponse response = placeService.getPlaceDetail(placeId);
-        return ApiResponse.of(HttpStatus.OK, "장소 상세 정보 조회 성공", response);
+    public ResponseEntity<ApiResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long placeId,
+                                                                           HttpServletRequest request,
+                                                                           HttpServletResponse response)
+    {
+        PlaceDetailResponse placeDetailResponse =
+                placeService.getPlaceDetail(placeId, request, response);;
+        return ApiResponse.of(HttpStatus.OK, "장소 상세 정보 조회 성공", placeDetailResponse);
     }
 
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceDetailResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceDetailResponse.java
@@ -9,6 +9,7 @@ import org.example.sejonglifebe.place.entity.PlaceImage;
 public record PlaceDetailResponse(
         Long id,
         String name,
+        Long viewCount,
         List<String> category,
         List<String> imageUrls,
         List<String> tags,
@@ -18,6 +19,7 @@ public record PlaceDetailResponse(
         return new PlaceDetailResponse(
                 place.getId(),
                 place.getName(),
+                place.getViewCount(),
                 place.getPlaceCategories().stream()
                         .map(placeCategory -> placeCategory.getCategory().getName())
                         .toList(),

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepository.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepository.java
@@ -6,6 +6,7 @@ import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.place.entity.Place;
 import org.example.sejonglifebe.tag.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -36,4 +37,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     @Query("SELECT p FROM Place p JOIN p.placeCategories pc WHERE pc.category = :category")
     List<Place> findByCategory(@Param("category") Category category);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Place p set p.viewCount = p.viewCount + 1 where p.id = :id")
+    void increaseViewCount(@Param("id") Long id);
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepository.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepository.java
@@ -39,6 +39,13 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     List<Place> findByCategory(@Param("category") Category category);
 
     @Modifying(clearAutomatically = true)
-    @Query("update Place p set p.viewCount = p.viewCount + 1 where p.id = :id")
+    @Query("UPDATE Place p SET p.viewCount = p.viewCount + 1, p.weeklyViewCount = p.weeklyViewCount + 1 WHERE p.id = :id")
     void increaseViewCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Place p SET p.weeklyViewCount = 0")
+    void resetAllWeeklyViewCounts();
+
+    List<Place> findTop10ByOrderByWeeklyViewCountDesc();
+
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -3,7 +3,6 @@ package org.example.sejonglifebe.place;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,6 +14,7 @@ import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.category.CategoryRepository;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.place.dto.HotPlaceResponse;
 import org.example.sejonglifebe.place.dto.PlaceRequest;
 import org.example.sejonglifebe.place.dto.PlaceResponse;
 import org.example.sejonglifebe.place.entity.Place;
@@ -100,5 +100,11 @@ public class PlaceService {
 
             response.addCookie(updatedCookie);
         }
+    }
+
+    public List<HotPlaceResponse> getWeeklyHotPlaces() {
+        List<Place> hotPlaces = placeRepository.findTop10ByOrderByWeeklyViewCountDesc();
+        return hotPlaces.stream()
+                .map(HotPlaceResponse::from).toList();
     }
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -79,10 +79,10 @@ public class PlaceService {
     }
 
     public void increaseViewCount(Long placeId, HttpServletRequest request, HttpServletResponse response) {
-        Optional<Cookie> placeViewCookie = (request.getCookies() == null) ? Optional.empty() :
-                Arrays.stream(request.getCookies())
+        Optional<Cookie> placeViewCookie = Optional.ofNullable(request.getCookies())
+                .flatMap(cookies -> Arrays.stream(cookies)
                         .filter(cookie -> cookie.getName().equals("placeView"))
-                        .findFirst();
+                        .findFirst());
 
         boolean shouldIncreaseViewCount = placeViewCookie
                 .map(cookie -> !cookie.getValue().contains("[" + placeId + "]"))

--- a/src/main/java/org/example/sejonglifebe/place/dto/HotPlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/HotPlaceResponse.java
@@ -1,0 +1,47 @@
+package org.example.sejonglifebe.place.dto;
+
+import java.util.List;
+import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.place.entity.PlaceCategory;
+import org.example.sejonglifebe.place.entity.PlaceTag;
+
+public record HotPlaceResponse(
+        Long placeId,
+        String placeName,
+        String mainImageUrl,
+        List<CategoryInfo> categories,
+        List<TagInfo> tags
+) {
+
+    public static HotPlaceResponse from(Place place) {
+        return new HotPlaceResponse(
+                place.getId(),
+                place.getName(),
+                place.getMainImageUrl(),
+                place.getPlaceCategories().stream()
+                        .map(CategoryInfo::from)
+                        .toList(),
+                place.getPlaceTags().stream()
+                        .map(TagInfo::from)
+                        .toList()
+        );
+    }
+
+    public record TagInfo(
+            Long tagId,
+            String tagName
+    ) {
+        public static TagInfo from(PlaceTag placeTag) {
+            return new TagInfo(placeTag.getTag().getId(), placeTag.getTag().getName());
+        }
+    }
+
+    public record CategoryInfo(
+            Long categoryId,
+            String categoryName
+    ) {
+        public static CategoryInfo from(PlaceCategory placeCategory) {
+            return new CategoryInfo(placeCategory.getCategory().getId(), placeCategory.getCategory().getName());
+        }
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/place/entity/Place.java
+++ b/src/main/java/org/example/sejonglifebe/place/entity/Place.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.place.util.MapLinkConverter;
 import org.example.sejonglifebe.tag.Tag;
@@ -47,6 +48,7 @@ public class Place {
     @Column(nullable = false)
     private Long viewCount;
 
+    @Setter
     @Column(nullable = false)
     private Long weeklyViewCount;
 
@@ -105,4 +107,5 @@ public class Place {
                 .map(PlaceImage::getUrl) // 그 이미지의 URL을 반환
                 .orElse(placeImages.get(0).getUrl()); // 만약 대표 이미지가 없다면, 그냥 첫 번째 이미지 반환
     }
+
 }

--- a/src/main/java/org/example/sejonglifebe/place/entity/Place.java
+++ b/src/main/java/org/example/sejonglifebe/place/entity/Place.java
@@ -47,6 +47,9 @@ public class Place {
     @Column(nullable = false)
     private Long viewCount;
 
+    @Column(nullable = false)
+    private Long weeklyViewCount;
+
     @OneToMany(mappedBy = "place", cascade = CascadeType.PERSIST)
     private List<PlaceImage> placeImages = new ArrayList<>();
 
@@ -64,6 +67,7 @@ public class Place {
         this.address = address;
         this.mapLinks = mapLinks;
         this.viewCount = 0L;
+        this.weeklyViewCount = 0L;
     }
 
     public void addImage(String imageUrl, Boolean isThumbnail) {

--- a/src/main/java/org/example/sejonglifebe/place/entity/Place.java
+++ b/src/main/java/org/example/sejonglifebe/place/entity/Place.java
@@ -44,6 +44,9 @@ public class Place {
     @Column(unique = true)
     private String mainImageUrl;
 
+    @Column(nullable = false)
+    private Long viewCount;
+
     @OneToMany(mappedBy = "place", cascade = CascadeType.PERSIST)
     private List<PlaceImage> placeImages = new ArrayList<>();
 
@@ -60,6 +63,7 @@ public class Place {
         this.name = name;
         this.address = address;
         this.mapLinks = mapLinks;
+        this.viewCount = 0L;
     }
 
     public void addImage(String imageUrl, Boolean isThumbnail) {

--- a/src/main/java/org/example/sejonglifebe/place/util/ViewCountScheduler.java
+++ b/src/main/java/org/example/sejonglifebe/place/util/ViewCountScheduler.java
@@ -1,0 +1,23 @@
+package org.example.sejonglifebe.place.util;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sejonglifebe.place.PlaceRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewCountScheduler {
+    private final PlaceRepository placeRepository;
+
+    //매주 월요일 00:00에 주간 조회수를 0으로 초기화
+    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    @Transactional
+    public void resetWeeklyViewCounts() {
+        placeRepository.resetAllWeeklyViewCounts();
+        log.info("주간 조회수 집계 초기화.");
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
@@ -218,12 +218,10 @@ public class PlaceControllerTest {
     }
 
     @Test
-    @DisplayName("장소 상세 조회 시 쿠키가 없으면 조회수가 1 증가하고 쿠키를 발급한다")
+    @DisplayName("장소 상세 조회 시 쿠키가 없으면 전체/주간 조회수가 1 증가하고 쿠키를 발급한다")
     void getPlaceDetail_noCookie_increaseViewCount() throws Exception {
-        // given: detailPlace의 초기 조회수는 0
         Long placeId = detailPlace.getId();
 
-        // when & then
         mockMvc.perform(get("/api/places/" + placeId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -231,37 +229,34 @@ public class PlaceControllerTest {
                 .andExpect(cookie().exists("placeView"))
                 .andExpect(cookie().value("placeView", "[" + placeId + "]"));
 
-        // DB 직접 검증
         Place updatedPlace = placeRepository.findById(placeId).get();
         assertThat(updatedPlace.getViewCount()).isEqualTo(1);
+        assertThat(updatedPlace.getWeeklyViewCount()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("장소 상세 조회 시 동일한 장소 ID 쿠키가 있으면 조회수가 증가하지 않는다")
     void getPlaceDetail_withSamePlaceCookie_doesNotIncreaseViewCount() throws Exception {
-        // given
         Long placeId = detailPlace.getId();
         Cookie placeViewCookie = new Cookie("placeView", "[" + placeId + "]");
 
-        // when & then
         mockMvc.perform(get("/api/places/" + placeId)
                         .cookie(placeViewCookie))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.viewCount").value(0)); // API 응답의 조회수는 기존 값(0)이어야 함
+                .andExpect(jsonPath("$.data.viewCount").value(0));
 
         Place notUpdatedPlace = placeRepository.findById(placeId).get();
         assertThat(notUpdatedPlace.getViewCount()).isEqualTo(0);
+        assertThat(notUpdatedPlace.getWeeklyViewCount()).isEqualTo(0);
     }
 
     @Test
     @DisplayName("장소 상세 조회 시 다른 장소 ID 쿠키가 있으면 조회수가 1 증가하고 쿠키를 갱신한다")
     void getPlaceDetail_withAnotherPlaceCookie_increaseViewCount() throws Exception {
-        // given
         Long placeId = detailPlace.getId();
         Long anotherPlaceId = 99L;
         Cookie placeViewCookie = new Cookie("placeView", "[" + anotherPlaceId + "]");
 
-        // when & then
         mockMvc.perform(get("/api/places/" + placeId)
                         .cookie(placeViewCookie))
                 .andExpect(status().isOk())
@@ -271,6 +266,7 @@ public class PlaceControllerTest {
 
         Place updatedPlace = placeRepository.findById(placeId).get();
         assertThat(updatedPlace.getViewCount()).isEqualTo(1);
+        assertThat(updatedPlace.getWeeklyViewCount()).isEqualTo(1);
     }
 
     @Test
@@ -287,15 +283,11 @@ public class PlaceControllerTest {
         mockMvc.perform(get("/api/places/hot") // 핫플레이스 조회 API 엔드포인트
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("주간 핫플레이스 조회 성공"))
-                .andExpect(jsonPath("$.data.length()").value(3))
-                // 정렬 순서 및 weeklyViewCount 값 동시 검증
-                .andExpect(jsonPath("$.data[0].name").value("카페3"))
-                .andExpect(jsonPath("$.data[0].weeklyViewCount").value(200)) // <-- 추가된 검증
-                .andExpect(jsonPath("$.data[1].name").value("식당1"))
-                .andExpect(jsonPath("$.data[1].weeklyViewCount").value(100)) // <-- 추가된 검증
-                .andExpect(jsonPath("$.data[2].name").value("식당2"))
-                .andExpect(jsonPath("$.data[2].weeklyViewCount").value(50))   // <-- 추가된 검증
+                .andExpect(jsonPath("$.message").value("핫플레이스 조회 성공"))
+                .andExpect(jsonPath("$.data.length()").value(6))
+                .andExpect(jsonPath("$.data[0].placeName").value("카페3"))
+                .andExpect(jsonPath("$.data[1].placeName").value("식당1"))
+                .andExpect(jsonPath("$.data[2].placeName").value("식당2"))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
---

## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #41 

---

## 📝 주요 변경 내용

- 장소 상세 정보 조회 시에 장소의 조회수 증가 구현
- 이번 주 조회수가 가장 많은 장소 10개를 핫 플레이스로 조회하도록 구현
- 각 기능의 테스트 코드 추가

---

## 🛠️ 작업 상세 내역

- @Modifying과 Update 쿼리를 통해 상세 정보 조회 메서드 호출시 조회수가 증가하도록 구현
- Cookie를 이용해 사용자가 조회한 장소id를 Cookie에 저장하고 쿠키의 유효기간을 24시간으로 갱신하여 중복 조회를 방지
- 조회수 증가 시 weeklyViewCount를 함께 증가시키고 스케줄러를 이용해 일->월 넘어가는 자정에 weeklyViewCount 초기화
- weeklyViewCount가 가장 높은 10개의 장소를 핫 플레이스로 조회

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 테스트 코드에 잘못된 부분이나 더 검증할 부분이 있는지 봐 주시면 감사하겠습니다
- 새로운 기능을 사용한 부분에서 발생할 가능성이 있는 문제를 봐주시면 좋겠습니다
- 추가로 비즈니스 로직 상 논의해 볼 사항도 얘기해 주시면 감사하겠습니다

---