### PR TITLE
fix: 장소 목록 조회 시 조회수 및 리뷰 수 반환

### DIFF
--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
@@ -10,6 +10,8 @@ public record PlaceResponse(
         Long placeId,
         String placeName,
         String thumbnailImageUrl,
+        Long viewCount,
+        Long reviewCount,
         List<CategoryInfo> categories,
         List<TagInfo> tags
 ) {
@@ -19,6 +21,8 @@ public record PlaceResponse(
                 place.getId(),
                 place.getName(),
                 place.getThumbnailImage(),
+                place.getViewCount(),
+                (long) place.getReviews().size(),
                 place.getPlaceCategories().stream()
                         .map(pc -> new CategoryInfo(pc.getCategory().getId(), pc.getCategory().getName()))
                         .toList(),

--- a/src/main/java/org/example/sejonglifebe/place/entity/Place.java
+++ b/src/main/java/org/example/sejonglifebe/place/entity/Place.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.place.util.MapLinkConverter;
+import org.example.sejonglifebe.review.Review;
 import org.example.sejonglifebe.tag.Tag;
 import org.hibernate.annotations.BatchSize;
 
@@ -63,6 +64,9 @@ public class Place {
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlaceCategory> placeCategories = new ArrayList<>();
 
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
     @Builder
     public Place(String name, String address, MapLinks mapLinks, String mainImageUrl) {
         this.name = name;
@@ -94,6 +98,10 @@ public class Place {
         if (!exists) {
             PlaceCategory.createPlaceCategory(this, category);
         }
+    }
+
+    public void addReview(Review review) {
+        reviews.add(review);
     }
 
     public String getThumbnailImage() {

--- a/src/main/java/org/example/sejonglifebe/review/Review.java
+++ b/src/main/java/org/example/sejonglifebe/review/Review.java
@@ -90,6 +90,7 @@ public class Review {
                 .content(content)
                 .build();
 
+        place.addReview(review);
         user.addReview(review);
         return review;
     }

--- a/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
@@ -110,6 +110,8 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(6))
+                .andExpect(jsonPath("$.data[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
                 .andDo(print());
     }
 
@@ -127,8 +129,14 @@ public class PlaceControllerTest {
 
                 // 정렬 순서 검증
                 .andExpect(jsonPath("$.data[0].placeName").value("식당3")) // 첫 번째 결과는 태그 2개인 '식당3'
+                .andExpect(jsonPath("$.data[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
                 .andExpect(jsonPath("$.data[1].placeName").value("식당1")) // 두 번째 결과는 '식당1'
-                .andExpect(jsonPath("$.data[2].placeName").value("식당2")); // 세 번째 결과는 '식당2'
+                .andExpect(jsonPath("$.data[1].viewCount").value(0))
+                .andExpect(jsonPath("$.data[1].reviewCount").value(0))
+                .andExpect(jsonPath("$.data[2].placeName").value("식당2")) // 세 번째 결과는 '식당2'
+                .andExpect(jsonPath("$.data[2].viewCount").value(0))
+                .andExpect(jsonPath("$.data[2].reviewCount").value(0));
     }
 
     @Test
@@ -141,8 +149,14 @@ public class PlaceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(3))
                 .andExpect(jsonPath("$.data[0].placeName").value("식당1"))
+                .andExpect(jsonPath("$.data[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
                 .andExpect(jsonPath("$.data[1].placeName").value("식당2"))
-                .andExpect(jsonPath("$.data[2].placeName").value("식당3"));
+                .andExpect(jsonPath("$.data[1].viewCount").value(0))
+                .andExpect(jsonPath("$.data[1].reviewCount").value(0))
+                .andExpect(jsonPath("$.data[2].placeName").value("식당3"))
+                .andExpect(jsonPath("$.data[2].viewCount").value(0))
+                .andExpect(jsonPath("$.data[2].reviewCount").value(0));
     }
 
     @Test
@@ -156,7 +170,11 @@ public class PlaceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(2))
                 .andExpect(jsonPath("$.data[0].placeName").value("카페1"))
-                .andExpect(jsonPath("$.data[1].placeName").value("카페3"));
+                .andExpect(jsonPath("$.data[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
+                .andExpect(jsonPath("$.data[1].placeName").value("카페3"))
+                .andExpect(jsonPath("$.data[1].viewCount").value(0))
+                .andExpect(jsonPath("$.data[1].reviewCount").value(0));
     }
 
     @Test


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #46 

---

## 📝 주요 변경 내용

- 장소 목록 조회 시 응답에 조회수랑 리뷰 수가

---

## 🛠️ 작업 상세 내역

- ReviewCount를 세기 위해 양방향으로 Review와 Place를 연결
- PlaceResponse에 viewCount와 reivewCount 필드를 추가하여 반환값으로 추가
- test에 조회수와 리뷰 수 반환 검증 추가

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 컨벤션 놓친 부분 신경 써주시면 감사하겠습니다!

---