### PR TITLE
refactor: swagger-ui 개선 

### DIFF
--- a/src/main/java/org/example/sejonglifebe/auth/LoginController.java
+++ b/src/main/java/org/example/sejonglifebe/auth/LoginController.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
@@ -15,12 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증/인가")
 public class LoginController {
 
     private final LoginService loginService;
 
+    @Operation(summary = "로그인")
     @PostMapping("/login")
-    public ResponseEntity<CommonResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<CommonResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request) {
         LoginResponse response = loginService.login(request);
         return CommonResponse.of(HttpStatus.OK, "로그인 성공", response);
     }

--- a/src/main/java/org/example/sejonglifebe/auth/dto/LoginRequest.java
+++ b/src/main/java/org/example/sejonglifebe/auth/dto/LoginRequest.java
@@ -1,16 +1,20 @@
 package org.example.sejonglifebe.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "로그인 요청")
 public class LoginRequest {
 
+    @Schema(description = "세종 포털 아이디", example = "20231234")
     @NotBlank(message = "아이디는 필수 입력 값입니다.")
     private String sejongPortalId;
 
+    @Schema(description = "세종 포털 비밀번호", example = "p@ssw0rd!")
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     private String sejongPortalPw;
 }

--- a/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
+++ b/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
@@ -1,6 +1,7 @@
 package org.example.sejonglifebe.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
@@ -8,17 +9,29 @@ import org.example.sejonglifebe.auth.PortalStudentInfo;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "로그인 응답")
 public class LoginResponse {
 
+    @Schema(description = "신규 회원 여부", example = "false")
     private final boolean isNewUser;
-    private final String accessToken; // 기존 회원용 JWT
-    private final String signUpToken; // 신규 회원용 임시 토큰
-    private final UserInfo userInfo; // 신규 회원용 기본 정보
+
+    @Schema(description = "기존 회원용 접근 토큰(JWT)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private final String accessToken;
+
+    @Schema(description = "신규 회원용 가입 토큰(임시)", example = "eyJhbGciOiJIUzI1NiJ9...")
+    private final String signUpToken;
+
+    @Schema(description = "신규 회원 기본 정보")
+    private final UserInfo userInfo;
 
     @Getter
     @Builder
+    @Schema(description = "사용자 기본 정보")
     public static class UserInfo {
+        @Schema(description = "학번", example = "20231234")
         private String studentId;
+
+        @Schema(description = "이름", example = "홍길동")
         private String name;
 
         public static UserInfo from(PortalStudentInfo portalInfo) {
@@ -29,7 +42,9 @@ public class LoginResponse {
         }
     }
 
-    // 기존 회원일 때 : 로그인 성공
+    /**
+     * 기존 회원일 때 : 로그인 성공, access token 발급
+     */
     public static LoginResponse loginSuccess(String accessToken) {
         return LoginResponse.builder()
                 .isNewUser(false)
@@ -37,7 +52,9 @@ public class LoginResponse {
                 .build();
     }
 
-    // 신규 회원일 때 : 회원가입 필요
+    /**
+     * 신규 회원일 때 : 회원가입 필요, sign-up token 발급, 포털에서 가져온 기본 정보 제공
+     */
     public static LoginResponse signUpRequired(String signUpToken, PortalStudentInfo portalInfo) {
         return LoginResponse.builder()
                 .isNewUser(true)

--- a/src/main/java/org/example/sejonglifebe/category/CategoryController.java
+++ b/src/main/java/org/example/sejonglifebe/category/CategoryController.java
@@ -1,10 +1,6 @@
 package org.example.sejonglifebe.category;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.category.dto.CategoryResponse;
@@ -20,18 +16,12 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
-@Tag(name = "Category API", description = "카테고리 API")
+@Tag(name = "Category", description = "카테고리")
 public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @Operation(summary = "카테고리 목록 조회", description = "전체 카테고리 목록을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "전체 카테고리 목록 조회 성공",
-                    content = @Content(schema = @Schema(implementation = CategoryResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = CategoryResponse.class)))
-    })
+    @Operation(summary = "카테고리 목록 조회")
     @GetMapping
     public ResponseEntity<CommonResponse<List<CategoryResponse>>> getCategories() {
         List<CategoryResponse> categoryResponses = categoryService.getCategories();

--- a/src/main/java/org/example/sejonglifebe/category/dto/CategoryResponse.java
+++ b/src/main/java/org/example/sejonglifebe/category/dto/CategoryResponse.java
@@ -1,9 +1,14 @@
 package org.example.sejonglifebe.category.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.category.Category;
 
+@Schema(description = "카테고리 정보")
 public record CategoryResponse(
+        @Schema(description = "카테고리 ID", example = "3")
         Long categoryId,
+
+        @Schema(description = "카테고리명", example = "카페")
         String categoryName
 ) {
 

--- a/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
@@ -17,8 +17,12 @@ public class SwaggerConfig {
         localServer.setUrl("http://localhost:8080");
         localServer.setDescription("Local Server");
 
+        Server devServer = new Server();
+        devServer.setUrl("http://3.37.62.143:8081");
+        devServer.setDescription("Development Server");
+
         Server apiServer = new Server();
-        apiServer.setUrl("http://sejong-life.site");
+        apiServer.setUrl("https://sejong-life.site");
         apiServer.setDescription("Production Server");
 
         return new OpenAPI()

--- a/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
@@ -1,35 +1,36 @@
 package org.example.sejonglifebe.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
+@ConfigurationProperties(prefix = "swagger")
 public class SwaggerConfig {
+
+    private final List<Server> servers = new ArrayList<>();
 
     @Bean
     public OpenAPI customOpenAPI() {
-        Server localServer = new Server();
-        localServer.setUrl("http://localhost:8080");
-        localServer.setDescription("Local Server");
-
-        Server devServer = new Server();
-        devServer.setUrl("http://3.37.62.143:8081");
-        devServer.setDescription("Development Server");
-
-        Server apiServer = new Server();
-        apiServer.setUrl("https://sejong-life.site");
-        apiServer.setDescription("Production Server");
 
         return new OpenAPI()
-                .info(new Info()
-                        .title("SejongLife API")
-                        .version("1.0")
-                        .description("SejongLife API v1"))
-                .servers(Arrays.asList(localServer, apiServer));
+                .components(new Components().addSecuritySchemes("bearerAuth",
+                        new SecurityScheme()
+                                .name("Authorization")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .info(new Info().title("SejongLife API").version("1.0").description("SejongLife API v1"))
+                .servers(servers);
     }
 }

--- a/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/SwaggerConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,7 +18,11 @@ import java.util.List;
 @ConfigurationProperties(prefix = "swagger")
 public class SwaggerConfig {
 
-    private final List<Server> servers = new ArrayList<>();
+    private final List<Server> servers;
+
+    public SwaggerConfig() {
+        this.servers = new ArrayList<>();
+    }
 
     @Bean
     public OpenAPI customOpenAPI() {

--- a/src/main/java/org/example/sejonglifebe/common/dto/CategoryInfo.java
+++ b/src/main/java/org/example/sejonglifebe/common/dto/CategoryInfo.java
@@ -1,8 +1,11 @@
 package org.example.sejonglifebe.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리 정보")
 public record CategoryInfo(
-        Long categoryId,
-        String categoryName
+        @Schema(description = "카테고리 ID", example = "3") Long categoryId,
+        @Schema(description = "카테고리명", example = "카페") String categoryName
 ) {
 
 }

--- a/src/main/java/org/example/sejonglifebe/common/dto/TagInfo.java
+++ b/src/main/java/org/example/sejonglifebe/common/dto/TagInfo.java
@@ -1,8 +1,11 @@
 package org.example.sejonglifebe.common.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "태그 정보")
 public record TagInfo(
-        Long tagId,
-        String tagName
+        @Schema(description = "태그 ID", example = "10") Long tagId,
+        @Schema(description = "태그명", example = "혼밥하기 좋은") String tagName
 ) {
 
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.place;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +24,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/places")
+@Tag(name = "Place", description = "장소")
 public class PlaceController {
 
     private final PlaceService placeService;
 
+    @Operation(summary = "장소 목록 조회")
     @GetMapping
     public ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
             @RequestParam(value = "tags", required = false) List<String> tags,
@@ -35,16 +39,19 @@ public class PlaceController {
         return CommonResponse.of(HttpStatus.OK, "장소 목록 조회 성공", response);
     }
 
+    @Operation(summary = "주간 핫플레이스 조회")
     @GetMapping("/hot")
     public ResponseEntity<CommonResponse<List<HotPlaceResponse>>> getHotPlaces() {
         List<HotPlaceResponse> hotPlaceResponses = placeService.getWeeklyHotPlaces();
         return CommonResponse.of(HttpStatus.OK, "핫플레이스 조회 성공", hotPlaceResponses);
     }
 
+    @Operation(summary = "장소 상세 정보 조회")
     @GetMapping("/{placeId}")
-    public ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlaceDetail(@PathVariable Long placeId,
-                                                                           HttpServletRequest request,
-                                                                           HttpServletResponse response) {
+    public ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlaceDetail(
+            @PathVariable Long placeId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
         PlaceDetailResponse placeDetailResponse = placeService.getPlaceDetail(placeId, request, response);
         return CommonResponse.of(HttpStatus.OK, "장소 상세 정보 조회 성공", placeDetailResponse);
     }

--- a/src/main/java/org/example/sejonglifebe/place/dto/HotPlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/HotPlaceResponse.java
@@ -1,16 +1,19 @@
 package org.example.sejonglifebe.place.dto;
 
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.place.entity.Place;
 import org.example.sejonglifebe.place.entity.PlaceCategory;
 import org.example.sejonglifebe.place.entity.PlaceTag;
 
+@Schema(description = "주간 핫플레이스 요약")
 public record HotPlaceResponse(
-        Long placeId,
-        String placeName,
-        String mainImageUrl,
-        List<CategoryInfo> categories,
-        List<TagInfo> tags
+        @Schema(description = "장소 ID", example = "3") Long placeId,
+        @Schema(description = "장소명", example = "세종 카페 101") String placeName,
+        @Schema(description = "대표 이미지 URL", example = "https://.../main.jpg") String mainImageUrl,
+        @Schema(description = "카테고리 목록") List<CategoryInfo> categories,
+        @Schema(description = "태그 목록") List<TagInfo> tags
 ) {
 
     public static HotPlaceResponse from(Place place) {

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceDetailResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceDetailResponse.java
@@ -2,19 +2,21 @@ package org.example.sejonglifebe.place.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.common.dto.CategoryInfo;
 import org.example.sejonglifebe.common.dto.TagInfo;
 import org.example.sejonglifebe.place.entity.MapLinks;
 import org.example.sejonglifebe.place.entity.Place;
 
+@Schema(description = "장소 상세 정보")
 public record PlaceDetailResponse(
-        Long id,
-        String name,
-        List<CategoryInfo> categories,
-        List<PlaceImageInfo> images,
-        List<TagInfo> tags,
-        Long viewCount,
-        MapLinks mapLinks
+        @Schema(description = "장소 ID", example = "101") Long id,
+        @Schema(description = "장소명", example = "보난자") String name,
+        @Schema(description = "카테고리 목록") List<CategoryInfo> categories,
+        @Schema(description = "이미지 정보 목록") List<PlaceImageInfo> images,
+        @Schema(description = "태그 목록") List<TagInfo> tags,
+        @Schema(description = "조회수", example = "12345") Long viewCount,
+        @Schema(description = "지도 링크(카카오/네이버/구글 등)") MapLinks mapLinks
 ) {
 
     public static PlaceDetailResponse from(Place place) {

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceImageInfo.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceImageInfo.java
@@ -1,9 +1,14 @@
 package org.example.sejonglifebe.place.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.place.entity.PlaceImage;
 
+@Schema(description = "장소 이미지 정보")
 public record PlaceImageInfo(
+        @Schema(description = "이미지 ID", example = "2")
         Long imageId,
+
+        @Schema(description = "이미지 URL", example = "https://.../image.jpg")
         String url
 ) {
 

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceRequest.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceRequest.java
@@ -1,9 +1,17 @@
 package org.example.sejonglifebe.place.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
+
 import java.util.List;
 
+@ParameterObject
+@Schema(description = "장소 목록 조회 필터")
 public record PlaceRequest(
+        @Schema(description = "필터링할 태그 목록", example = "[\"혼밥하기 좋은\",\"가성비 좋은\"]")
         List<String> tags,
+
+        @Schema(description = "조회할 카테고리", example = "카페")
         String category
 ) {
 

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
@@ -2,18 +2,20 @@ package org.example.sejonglifebe.place.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.common.dto.CategoryInfo;
 import org.example.sejonglifebe.common.dto.TagInfo;
 import org.example.sejonglifebe.place.entity.Place;
 
+@Schema(description = "장소 목록 아이템")
 public record PlaceResponse(
-        Long placeId,
-        String placeName,
-        String thumbnailImageUrl,
-        Long viewCount,
-        Long reviewCount,
-        List<CategoryInfo> categories,
-        List<TagInfo> tags
+        @Schema(description = "장소 ID", example = "101") Long placeId,
+        @Schema(description = "장소명", example = "세종 카페 101") String placeName,
+        @Schema(description = "썸네일 이미지 URL", example = "https://.../thumb.jpg") String thumbnailImageUrl,
+        @Schema(description = "조회수", example = "12345") Long viewCount,
+        @Schema(description = "리뷰 수", example = "12") Long reviewCount,
+        @Schema(description = "카테고리 목록") List<CategoryInfo> categories,
+        @Schema(description = "태그 목록") List<TagInfo> tags
 ) {
 
     public static PlaceResponse from(Place place) {

--- a/src/main/java/org/example/sejonglifebe/review/ReviewController.java
+++ b/src/main/java/org/example/sejonglifebe/review/ReviewController.java
@@ -2,6 +2,8 @@ package org.example.sejonglifebe.review;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthUser;
@@ -25,10 +27,12 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/places/{placeId}/reviews")
+@Tag(name = "Review", description = "리뷰")
 public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @Operation(summary = "리뷰 목록 조회")
     @GetMapping
     public ResponseEntity<CommonResponse<List<ReviewResponse>>> getReviews(
             @PathVariable("placeId") Long placeId,
@@ -36,32 +40,39 @@ public class ReviewController {
         return CommonResponse.of(HttpStatus.OK, "리뷰 목록 조회 성공", reviewService.getReviewsByPlaceId(placeId, authUser));
     }
 
+    @Operation(summary = "리뷰 요약 정보 조회")
     @GetMapping("/summary")
     public ResponseEntity<CommonResponse<ReviewSummaryResponse>> getReviewSummary(
             @PathVariable("placeId") Long placeId) {
         return CommonResponse.of(HttpStatus.OK, "리뷰 요약 정보 조회 성공", reviewService.getReviewSummaryByPlaceId(placeId));
     }
 
+    @Operation(summary = "리뷰 작성")
     @LoginRequired
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<CommonResponse<Void>> createReview(@PathVariable("placeId") Long placeId,
-                                                          @Valid @RequestPart("review") ReviewRequest reviewRequest,
-                                                          @RequestPart(value = "images", required = false) List<MultipartFile> images,
-                                                          AuthUser authUser) {
+    public ResponseEntity<CommonResponse<Void>> createReview(
+            @PathVariable("placeId") Long placeId,
+            @Valid @RequestPart("review") ReviewRequest reviewRequest,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            AuthUser authUser) {
         reviewService.createReview(placeId, reviewRequest, authUser);
         return CommonResponse.of(HttpStatus.CREATED, "리뷰 작성 성공", null);
     }
 
+    @Operation(summary = "리뷰 좋아요")
     @LoginRequired
     @PostMapping("/{reviewId}/likes")
-    public ResponseEntity<CommonResponse<Void>> createlike(@PathVariable("reviewId") Long reviewId, AuthUser authUser) {
+    public ResponseEntity<CommonResponse<Void>> createlike(
+            @PathVariable("reviewId") Long reviewId, AuthUser authUser) {
         reviewService.createLike(reviewId, authUser);
         return CommonResponse.of(HttpStatus.OK, "리뷰 좋아요 성공", null);
     }
 
+    @Operation(summary = "리뷰 좋아요 취소")
     @LoginRequired
     @DeleteMapping("/{reviewId}/likes")
-    public ResponseEntity<CommonResponse<Void>> deleteLike(@PathVariable("reviewId") Long reviewId, AuthUser authUser) {
+    public ResponseEntity<CommonResponse<Void>> deleteLike(
+            @PathVariable("reviewId") Long reviewId, AuthUser authUser) {
         reviewService.deleteLike(reviewId, authUser);
         return CommonResponse.of(HttpStatus.OK, "리뷰 좋아요 취소 성공", null);
     }

--- a/src/main/java/org/example/sejonglifebe/review/dto/RatingCount.java
+++ b/src/main/java/org/example/sejonglifebe/review/dto/RatingCount.java
@@ -1,8 +1,11 @@
 package org.example.sejonglifebe.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "별점-개수 집계")
 public record RatingCount(
-        int rating,
-        Long count
+        @Schema(description = "별점", example = "5") int rating,
+        @Schema(description = "개수", example = "12") Long count
 ) {
 
 }

--- a/src/main/java/org/example/sejonglifebe/review/dto/ReviewRequest.java
+++ b/src/main/java/org/example/sejonglifebe/review/dto/ReviewRequest.java
@@ -1,19 +1,24 @@
 package org.example.sejonglifebe.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
+@Schema(description = "리뷰 작성 요청")
 public record ReviewRequest(
-
+        @Schema(description = "별점(1~5)", example = "5")
         @Min(value = 1, message = "별점은 1 이상이어야 합니다.")
         @Max(value = 5, message = "별점은 5 이하여야 합니다.")
         int rating,
 
+        @Schema(description = "리뷰 내용", example = "분위기 좋고 커피가 맛있어요!")
         @NotBlank(message = "리뷰 내용은 필수 항목입니다.")
         String content,
+
+        @Schema(description = "태그 ID 목록", example = "[1,2,3]")
         List<Long> tagIds
 ) {
 

--- a/src/main/java/org/example/sejonglifebe/review/dto/ReviewResponse.java
+++ b/src/main/java/org/example/sejonglifebe/review/dto/ReviewResponse.java
@@ -2,23 +2,24 @@ package org.example.sejonglifebe.review.dto;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.common.dto.TagInfo;
 import org.example.sejonglifebe.place.entity.PlaceImage;
 import org.example.sejonglifebe.review.Review;
 
+@Schema(description = "리뷰 응답")
 public record ReviewResponse(
-        Long reviewId,
-        int rating,
-        Long userId,
-        String userName,
-        String studentId,
-        String content,
-        Long likeCount,
-        String createdAt,
-        boolean liked,
-        List<String> images,
-        List<TagInfo> tags
-
+        @Schema(description = "리뷰 ID", example = "9001") Long reviewId,
+        @Schema(description = "별점", example = "5") int rating,
+        @Schema(description = "작성자 ID", example = "123") Long userId,
+        @Schema(description = "작성자 닉네임", example = "카페덕후") String userName,
+        @Schema(description = "작성자 학번", example = "20230001") String studentId,
+        @Schema(description = "리뷰 내용", example = "커피가 진하고 맛있어요!") String content,
+        @Schema(description = "좋아요 수", example = "7") Long likeCount,
+        @Schema(description = "작성일시(ISO 문자열)", example = "2025-08-24T13:45:00") String createdAt,
+        @Schema(description = "내가 좋아요 눌렀는지", example = "true") boolean liked,
+        @Schema(description = "이미지 URL 목록") List<String> images,
+        @Schema(description = "태그 목록") List<TagInfo> tags
 ) {
 
     public static ReviewResponse from(Review review,boolean liked) {

--- a/src/main/java/org/example/sejonglifebe/review/dto/ReviewSummaryResponse.java
+++ b/src/main/java/org/example/sejonglifebe/review/dto/ReviewSummaryResponse.java
@@ -1,10 +1,15 @@
 package org.example.sejonglifebe.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Map;
 
+@Schema(description = "리뷰 요약 정보")
 public record ReviewSummaryResponse(
-        Long reviewCount,
-        Double averageRate,
+        @Schema(description = "리뷰 총 개수", example = "120") Long reviewCount,
+        @Schema(description = "평균 별점", example = "4.3") Double averageRate,
+
+        @Schema(description = "별점 분포(키: 별점, 값: 개수)", example = "{\"5\": 80, \"4\": 30, \"3\": 10}")
         Map<String, Long> ratingDistribution
 ) {
 

--- a/src/main/java/org/example/sejonglifebe/roulette/RouletteController.java
+++ b/src/main/java/org/example/sejonglifebe/roulette/RouletteController.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.roulette;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.roulette.dto.RouletteResponse;
 import org.springframework.http.ResponseEntity;
@@ -8,12 +10,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/roulette")
+@Tag(name = "Roulette", description = "룰렛 추천")
 public class RouletteController {
 
     private final RouletteService rouletteService;
 
+    @Operation(summary = "카테고리 기반 룰렛 추천")
     @GetMapping("/places/{categoryName}")
-    public ResponseEntity<RouletteResponse> getRoulettePlaces(@PathVariable String categoryName) {
+    public ResponseEntity<RouletteResponse> getRoulettePlaces(
+            @PathVariable String categoryName) {
         return ResponseEntity.ok(rouletteService.getRoulettePlaces(categoryName));
     }
 }

--- a/src/main/java/org/example/sejonglifebe/roulette/dto/RouletteResponse.java
+++ b/src/main/java/org/example/sejonglifebe/roulette/dto/RouletteResponse.java
@@ -1,10 +1,14 @@
 package org.example.sejonglifebe.roulette.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.place.entity.Place;
 
 import java.util.List;
 
-public record RouletteResponse(List<RoulettePlaceDto> places) {
+@Schema(description = "룰렛 추천 응답")
+public record RouletteResponse(
+        @Schema(description = "추천 장소 목록") List<RoulettePlaceDto> places
+) {
 
     public static RouletteResponse from(List<Place> places) {
         List<RoulettePlaceDto> dtoList = places.stream()
@@ -13,6 +17,7 @@ public record RouletteResponse(List<RoulettePlaceDto> places) {
         return new RouletteResponse(dtoList);
     }
 
+    @Schema(description = "룰렛 추천 항목")
     public record RoulettePlaceDto(Long placeId, String placeName) {
     }
 }

--- a/src/main/java/org/example/sejonglifebe/tag/dto/TagResponse.java
+++ b/src/main/java/org/example/sejonglifebe/tag/dto/TagResponse.java
@@ -1,10 +1,12 @@
 package org.example.sejonglifebe.tag.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.tag.Tag;
 
+@Schema(description = "태그 정보")
 public record TagResponse(
-        Long tagId,
-        String tagName
+        @Schema(description = "태그 ID", example = "10") Long tagId,
+        @Schema(description = "태그명", example = "혼밥하기 좋은")String tagName
 ) {
 
     public static TagResponse from(Tag tag) {

--- a/src/main/java/org/example/sejonglifebe/user/UserController.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserController.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.user;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
@@ -18,11 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Tag(name = "User", description = "회원")
 public class UserController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<String>> signup(
             @RequestHeader("Authorization") String signUpToken,

--- a/src/main/java/org/example/sejonglifebe/user/dto/SignUpRequest.java
+++ b/src/main/java/org/example/sejonglifebe/user/dto/SignUpRequest.java
@@ -1,5 +1,6 @@
 package org.example.sejonglifebe.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -8,14 +9,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "회원가입 요청")
 public class SignUpRequest {
 
+    @Schema(description = "학번", example = "20231234")
     @NotBlank(message = "학번은 필수입니다.")
     private String studentId;
 
+    @Schema(description = "이름", example = "홍길동")
     @NotBlank(message = "이름은 필수입니다.")
     private String name;
 
+    @Schema(description = "닉네임(2~10, 한글/영문/숫자)", example = "세종라떼")
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]*$", message = "닉네임은 한글, 영문, 숫자만 사용 가능합니다.")

--- a/src/main/java/org/example/sejonglifebe/user/dto/UserResponse.java
+++ b/src/main/java/org/example/sejonglifebe/user/dto/UserResponse.java
@@ -1,5 +1,7 @@
 package org.example.sejonglifebe.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,10 +9,14 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "사용자 응답")
 public class UserResponse {
 
-    private String studentId;
-    private String nickname;
+    @Schema(description = "학번", example = "20231234") private String studentId;
+    @Schema(description = "닉네임", example = "세종대왕") private String nickname;
+
+    @Schema(description = "가입일시", example = "2025-08-24T12:34:56")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime createdAt;
 
     public static UserResponse fromEntity(org.example.sejonglifebe.user.User user) {


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [x] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #15 

---

## 📝 주요 변경 내용

- 컨트롤러에 과도한 어노테이션을 줄이고자 아래(작업 상세 내역 참고) 규칙을 기준으로 swagger 어노테이션을 적용하였습니다.

---

## 🛠️ 작업 상세 내역

- SwaggerConfig
  - 서버 URL 하드코딩 제거 → `application.yml` 기반으로 주입
  - JWT Bearer 인증 스키마(`bearerAuth`) 추가 → Swagger UI에서 `Authorize` 버튼 제공
- applicatoin.yml 설정 수정
    ```
    springdoc:
      override-with-generic-response: true
      default-consumes-media-type: application/json
      default-produces-media-type: application/json
      show-javadoc: true
      swagger-ui:
        doc-expansion: list
        enabled: true
        operations-sorter: method
        path: "/swagger.html" # 기본값은 swagger-ui.html이나 편의를 위해 swagger.html로 변경
        tags-sorter: alpha
      api-docs:
        enabled: true # API 문서(`/v3/api-docs`) 활성화 여부 (기본값은 true)
        path: "/v3/api-docs" # 기본값 (논의 후 변경)
    
    server:
      forward-headers-strategy: framework
    
    swagger:
      servers:
        - url: http://localhost:8080
          description: Local Server
        - url: https://개발-서버(수정해주세요)
          description: Development Server
        - url: https://api.sejonglife.site
          description: Production Server
    ```
- Controller
  - 컨트롤러 클래스에는 `@Tag`만 적용
  - 각 메서드에는 `@Operation(summary=...)`만 적용
  - 불필요한 `@ApiResponses`, `@Content`, `@Schema` 제거
  - 요청 파라미터/응답 상세 설명은 DTO로 이동
- DTO
  - 클래스/필드에 `@Schema(description=..., example=...)`
  - 날짜/시간은 `@JsonFormat` 적용
  - 검증(`@NotBlank`, `@Size` 등)은 springdoc에서 자동 반영
  - 쿼리 파라미터 DTO는 `@ParameterObject` 활용

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 개발서버에 yml 설정 내역이 적용되도록 수정이 필요할 것 같습니다.
- controller를 단순화 하다보니 이번엔 또 dto 가 무거워졌네요.. 모든 필드에 @Schema 가 있어서 그런 것 같습니다.  추후 개발 시에 어디까지 @Schema를 붙일지 상의하면 좋을 것 같아요 🥹

---