### PR TITLE
feat: swagger MultipartFile 처리를 위한 컨버터 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/common/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/MultipartJackson2HttpMessageConverter.java
@@ -2,38 +2,23 @@ package org.example.sejonglifebe.common.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.sejonglifebe.review.dto.ReviewRequest;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import java.util.List;
 
 @Component
-public class MultipartJackson2HttpMessageConverter extends AbstractHttpMessageConverter<Object> {
-
-    private final ObjectMapper objectMapper;
+public class MultipartJackson2HttpMessageConverter extends MappingJackson2HttpMessageConverter {
 
     public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
-        super(MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM);
-        this.objectMapper = objectMapper;
+        super(objectMapper);
+        setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM));
     }
 
     @Override
-    protected boolean supports(Class<?> clazz) {
-        return clazz == ReviewRequest.class;
-    }
-
-    @Override
-    protected Object readInternal(Class<?> clazz, HttpInputMessage inputMessage)
-            throws IOException {
-        return objectMapper.readValue(inputMessage.getBody(), clazz);
-    }
-
-    @Override
-    protected void writeInternal(Object o, HttpOutputMessage outputMessage)
-            throws IOException {
-        outputMessage.getBody().write(objectMapper.writeValueAsBytes(o));
+    public boolean canRead(Class<?> clazz, @Nullable MediaType mediaType) {
+        return clazz == ReviewRequest.class && super.canRead(clazz, mediaType);
     }
 }

--- a/src/main/java/org/example/sejonglifebe/common/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,39 @@
+package org.example.sejonglifebe.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.sejonglifebe.review.dto.ReviewRequest;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractHttpMessageConverter<Object> {
+
+    private final ObjectMapper objectMapper;
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return clazz == ReviewRequest.class;
+    }
+
+    @Override
+    protected Object readInternal(Class<?> clazz, HttpInputMessage inputMessage)
+            throws IOException {
+        return objectMapper.readValue(inputMessage.getBody(), clazz);
+    }
+
+    @Override
+    protected void writeInternal(Object o, HttpOutputMessage outputMessage)
+            throws IOException {
+        outputMessage.getBody().write(objectMapper.writeValueAsBytes(o));
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/common/config/WebConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/WebConfig.java
@@ -1,9 +1,11 @@
 package org.example.sejonglifebe.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthInterceptor;
 import org.example.sejonglifebe.auth.AuthUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -26,6 +28,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/api/**");
+    }
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(new MultipartJackson2HttpMessageConverter(new ObjectMapper()));
     }
 
     /*


### PR DESCRIPTION

## 🔀 무엇을 위한 PR인가요?

- [X] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #56 

---

## 📝 주요 변경 내용
- MultipartFile 처리를 위한 컨버터를 구현했습니다.

---

## 🛠️ 작업 상세 내역
- Swagger에서는 multipart/form-data 요청 시 각 @RequestPart 타입을 정확히 구분하지 못해 기본적으로 application/octet-stream으로 전송됩니다. 이로 인해 JSON DTO를 정상적으로 매핑하지 못하는 문제가 있어 application/octet-stream도 JSON으로 처리할 수 있도록 HttpMessageConverter를 추가했습니다.
- 해당 컨버터를 WebConfig에 등록하여 리뷰 작성 요청에서 DTO 매핑이 정상 동작하도록 개선했습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 코드 개선 포인트 있으면 알려주세요
---