### PR TITLE
refactor: swagger 관련 코드 인터페이스로 분리

### DIFF
--- a/src/main/java/org/example/sejonglifebe/category/CategoryController.java
+++ b/src/main/java/org/example/sejonglifebe/category/CategoryController.java
@@ -1,7 +1,5 @@
 package org.example.sejonglifebe.category;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.category.dto.CategoryResponse;
 import org.example.sejonglifebe.common.dto.CommonResponse;
@@ -16,12 +14,10 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")
-@Tag(name = "Category", description = "카테고리")
-public class CategoryController {
+public class CategoryController implements CategoryControllerSwagger {
 
     private final CategoryService categoryService;
 
-    @Operation(summary = "카테고리 목록 조회")
     @GetMapping
     public ResponseEntity<CommonResponse<List<CategoryResponse>>> getCategories() {
         List<CategoryResponse> categoryResponses = categoryService.getCategories();

--- a/src/main/java/org/example/sejonglifebe/category/CategoryControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/category/CategoryControllerSwagger.java
@@ -1,0 +1,16 @@
+package org.example.sejonglifebe.category;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.sejonglifebe.category.dto.CategoryResponse;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "Category", description = "카테고리")
+public interface CategoryControllerSwagger {
+
+    @Operation(summary = "카테고리 목록 조회")
+    ResponseEntity<CommonResponse<List<CategoryResponse>>> getCategories();
+}

--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -1,7 +1,5 @@
 package org.example.sejonglifebe.place;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,12 +21,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/places")
-@Tag(name = "Place", description = "장소")
-public class PlaceController {
+public class PlaceController implements PlaceControllerSwagger {
 
     private final PlaceService placeService;
 
-    @Operation(summary = "장소 목록 조회")
     @GetMapping
     public ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
             @RequestParam(value = "tags", required = false) List<String> tags,
@@ -38,14 +34,12 @@ public class PlaceController {
         return CommonResponse.of(HttpStatus.OK, "장소 목록 조회 성공", response);
     }
 
-    @Operation(summary = "주간 핫플레이스 조회")
     @GetMapping("/hot")
     public ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces() {
         List<PlaceResponse> hotPlaceResponses = placeService.getWeeklyHotPlaces();
         return CommonResponse.of(HttpStatus.OK, "핫플레이스 조회 성공", hotPlaceResponses);
     }
 
-    @Operation(summary = "장소 상세 정보 조회")
     @GetMapping("/{placeId}")
     public ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlaceDetail(
             @PathVariable Long placeId,

--- a/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
@@ -1,0 +1,32 @@
+package org.example.sejonglifebe.place;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.place.dto.PlaceDetailResponse;
+import org.example.sejonglifebe.place.dto.PlaceResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Place", description = "장소")
+public interface PlaceControllerSwagger {
+
+    @Operation(summary = "장소 목록 조회")
+    ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
+            @RequestParam(value = "tags", required = false) List<String> tags,
+            @RequestParam(value = "category") String category);
+
+    @Operation(summary = "주간 핫플레이스 조회")
+    ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces();
+
+    @Operation(summary = "장소 상세 정보 조회")
+    ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlaceDetail(
+            @PathVariable Long placeId,
+            HttpServletRequest request,
+            HttpServletResponse response);
+}

--- a/src/main/java/org/example/sejonglifebe/review/ReviewController.java
+++ b/src/main/java/org/example/sejonglifebe/review/ReviewController.java
@@ -1,10 +1,7 @@
 package org.example.sejonglifebe.review;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthUser;
@@ -30,12 +27,11 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/places/{placeId}/reviews")
-@Tag(name = "Review", description = "리뷰")
-public class ReviewController {
+public class ReviewController implements ReviewControllerSwagger {
 
     private final ReviewService reviewService;
 
-    @Operation(summary = "리뷰 목록 조회")
+
     @GetMapping
     public ResponseEntity<CommonResponse<List<ReviewResponse>>> getReviews(
             @PathVariable("placeId") Long placeId,
@@ -43,27 +39,22 @@ public class ReviewController {
         return CommonResponse.of(HttpStatus.OK, "리뷰 목록 조회 성공", reviewService.getReviewsByPlaceId(placeId, authUser));
     }
 
-    @Operation(summary = "리뷰 요약 정보 조회")
     @GetMapping("/summary")
     public ResponseEntity<CommonResponse<ReviewSummaryResponse>> getReviewSummary(
             @PathVariable("placeId") Long placeId) {
         return CommonResponse.of(HttpStatus.OK, "리뷰 요약 정보 조회 성공", reviewService.getReviewSummaryByPlaceId(placeId));
     }
 
-    @Operation(summary = "리뷰 작성")
     @LoginRequired
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<Void>> createReview(
-            @Parameter(description = "리뷰를 작성할 장소의 ID", required = true, example = "1")
             @PathVariable("placeId") Long placeId,
 
             @Valid
             @RequestPart("review")
-            @Parameter(description = "리뷰 내용(JSON 형식)")
             ReviewRequest reviewRequest,
 
             @RequestPart(value = "images", required = false)
-            @Parameter(description = "업로드할 이미지 파일 목록")
             List<MultipartFile> images,
 
             AuthUser authUser) {
@@ -71,7 +62,6 @@ public class ReviewController {
         return CommonResponse.of(HttpStatus.CREATED, "리뷰 작성 성공", null);
     }
 
-    @Operation(summary = "리뷰 수정")
     @LoginRequired
     @PutMapping("/{reviewId}")
     public ResponseEntity<CommonResponse<Void>> updateReview(
@@ -85,7 +75,6 @@ public class ReviewController {
         return CommonResponse.of(HttpStatus.OK, "리뷰 수정 성공", null);
     }
 
-    @Operation(summary = "리뷰 삭제")
     @LoginRequired
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<CommonResponse<Void>> deleteReview(
@@ -98,16 +87,14 @@ public class ReviewController {
         return CommonResponse.of(HttpStatus.OK, "리뷰 삭제 성공", null);
     }
 
-    @Operation(summary = "리뷰 좋아요")
     @LoginRequired
     @PostMapping("/{reviewId}/likes")
-    public ResponseEntity<CommonResponse<Void>> createlike(
+    public ResponseEntity<CommonResponse<Void>> createLike(
             @PathVariable("reviewId") Long reviewId, AuthUser authUser) {
         reviewService.createLike(reviewId, authUser);
         return CommonResponse.of(HttpStatus.OK, "리뷰 좋아요 성공", null);
     }
 
-    @Operation(summary = "리뷰 좋아요 취소")
     @LoginRequired
     @DeleteMapping("/{reviewId}/likes")
     public ResponseEntity<CommonResponse<Void>> deleteLike(

--- a/src/main/java/org/example/sejonglifebe/review/ReviewControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/review/ReviewControllerSwagger.java
@@ -1,0 +1,68 @@
+package org.example.sejonglifebe.review;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.sejonglifebe.auth.AuthUser;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.review.dto.ReviewRequest;
+import org.example.sejonglifebe.review.dto.ReviewResponse;
+import org.example.sejonglifebe.review.dto.ReviewSummaryResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "Review", description = "리뷰")
+public interface ReviewControllerSwagger {
+
+    @Operation(summary = "리뷰 목록 조회")
+    ResponseEntity<CommonResponse<List<ReviewResponse>>> getReviews(
+            @PathVariable("placeId") Long placeId,
+            AuthUser authUser);
+
+    @Operation(summary = "리뷰 요약 정보 조회")
+    ResponseEntity<CommonResponse<ReviewSummaryResponse>> getReviewSummary(
+            @PathVariable("placeId") Long placeId);
+
+    @Operation(summary = "리뷰 작성")
+    ResponseEntity<CommonResponse<Void>> createReview(
+            @Parameter(description = "리뷰를 작성할 장소의 ID", required = true, example = "1")
+            @PathVariable("placeId") Long placeId,
+
+            @Valid
+            @RequestPart("review")
+            @Parameter(description = "리뷰 내용(JSON 형식)")
+            ReviewRequest reviewRequest,
+
+            @RequestPart(value = "images", required = false)
+            @Parameter(description = "업로드할 이미지 파일 목록")
+            List<MultipartFile> images,
+
+            AuthUser authUser);
+
+    @Operation(summary = "리뷰 수정")
+    ResponseEntity<CommonResponse<Void>> updateReview(
+            @PathVariable Long placeId,
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewRequest reviewRequest,
+            AuthUser authUser);
+
+    @Operation(summary = "리뷰 삭제")
+    ResponseEntity<CommonResponse<Void>> deleteReview(
+            @PathVariable Long placeId,
+            @PathVariable Long reviewId,
+            AuthUser authUser);
+
+    @Operation(summary = "리뷰 좋아요")
+    ResponseEntity<CommonResponse<Void>> createLike(
+            @PathVariable("reviewId") Long reviewId, AuthUser authUser);
+
+    @Operation(summary = "리뷰 좋아요 취소")
+    ResponseEntity<CommonResponse<Void>> deleteLike(
+            @PathVariable("reviewId") Long reviewId, AuthUser authUser);
+}

--- a/src/main/java/org/example/sejonglifebe/roulette/RouletteController.java
+++ b/src/main/java/org/example/sejonglifebe/roulette/RouletteController.java
@@ -1,7 +1,5 @@
 package org.example.sejonglifebe.roulette;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.roulette.dto.RouletteResponse;
 import org.springframework.http.ResponseEntity;
@@ -10,12 +8,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/roulette")
-@Tag(name = "Roulette", description = "룰렛 추천")
-public class RouletteController {
+public class RouletteController implements RouletteControllerSwagger {
 
     private final RouletteService rouletteService;
 
-    @Operation(summary = "카테고리 기반 룰렛 추천")
     @GetMapping("/places/{categoryName}")
     public ResponseEntity<RouletteResponse> getRoulettePlaces(
             @PathVariable String categoryName) {

--- a/src/main/java/org/example/sejonglifebe/roulette/RouletteControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/roulette/RouletteControllerSwagger.java
@@ -1,0 +1,15 @@
+package org.example.sejonglifebe.roulette;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.sejonglifebe.roulette.dto.RouletteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Roulette", description = "룰렛 추천")
+public interface RouletteControllerSwagger {
+
+    @Operation(summary = "카테고리 기반 룰렛 추천")
+    ResponseEntity<RouletteResponse> getRoulettePlaces(
+            @PathVariable String categoryName);
+}

--- a/src/main/java/org/example/sejonglifebe/tag/TagController.java
+++ b/src/main/java/org/example/sejonglifebe/tag/TagController.java
@@ -1,8 +1,5 @@
 package org.example.sejonglifebe.tag;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.common.dto.CommonResponse;
 import org.example.sejonglifebe.tag.dto.TagResponse;
@@ -18,15 +15,12 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/tags")
-@Tag(name = "Tag API", description = "태그 API")
-public class TagController {
+public class TagController implements  TagControllerSwagger{
 
     private final TagService tagService;
 
-    @Operation(summary = "태그 목록 조회", description = "카테고리별 태그 목록을 조회합니다.")
     @GetMapping()
     public ResponseEntity<CommonResponse<List<TagResponse>>> getTags(
-            @Parameter(description = "조회할 카테고리 ID", required = false)
             @RequestParam(value = "categoryId", required = false) Long categoryId) {
         List<TagResponse> tagResponses = tagService.getTagsByCategoryId(categoryId);
         return CommonResponse.of(HttpStatus.OK, "전체 태그 목록 조회 성공", tagResponses);

--- a/src/main/java/org/example/sejonglifebe/tag/TagControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/tag/TagControllerSwagger.java
@@ -1,0 +1,24 @@
+package org.example.sejonglifebe.tag;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.tag.dto.TagResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Tag API", description = "태그 API")
+public interface TagControllerSwagger {
+
+    @Operation(summary = "태그 목록 조회", description = "카테고리별 태그 목록을 조회합니다.")
+    ResponseEntity<CommonResponse<List<TagResponse>>> getTags(
+            @Parameter(description = "조회할 카테고리 ID", required = false)
+            @RequestParam(value = "categoryId", required = false) Long categoryId);
+
+    @Operation(summary = "추천 태그 목록 조회", description = "해당 장소의 카테고리에서 많이 사용된 태그를 조회합니다.")
+    ResponseEntity<CommonResponse<List<TagResponse>>> getFrequentlyUsedTagsByCategoryId(@RequestParam(value = "categoryId") Long categoryId);
+
+}

--- a/src/main/java/org/example/sejonglifebe/user/UserController.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserController.java
@@ -1,7 +1,5 @@
 package org.example.sejonglifebe.user;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
@@ -22,14 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@Tag(name = "User", description = "회원")
-public class UserController {
+public class UserController implements UserControllerSwagger{
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenExtractor jwtTokenExtractor;
 
-    @Operation(summary = "회원가입")
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<String>> signup(
             @RequestHeader("Authorization") String signUpToken,

--- a/src/main/java/org/example/sejonglifebe/user/UserControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserControllerSwagger.java
@@ -1,0 +1,19 @@
+package org.example.sejonglifebe.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.user.dto.SignUpRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "User", description = "회원")
+public interface UserControllerSwagger {
+
+    @Operation(summary = "회원가입")
+    ResponseEntity<CommonResponse<String>> signup(
+            @RequestHeader("Authorization") String signUpToken,
+            @Valid @RequestBody SignUpRequest request);
+}


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #83 

---

## 📝 주요 변경 내용

- 운영 코드와 문서화 관련 코드의 역할을 분리하기위해서 swagger를 인터페이스를 통해 분리했습니다.

---

## 🛠️ 작업 상세 내역

-
-

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---