### PR TITLE
feat: 관리자 리뷰 로그 sse로 실시간 반영 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/common/config/AsyncConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/AsyncConfig.java
@@ -1,0 +1,38 @@
+package org.example.sejonglifebe.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("review-sse");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> {
+            log.error("[ASYNC UNEXPECTED ERROR]: Method: {}, Exception: {}", method.getName(), ex.getMessage(), ex);
+        };
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/review/ReviewService.java
+++ b/src/main/java/org/example/sejonglifebe/review/ReviewService.java
@@ -24,6 +24,7 @@ import org.example.sejonglifebe.user.UserRepository;
 import org.example.sejonglifebe.review.dto.RatingCount;
 import org.example.sejonglifebe.review.dto.ReviewResponse;
 import org.example.sejonglifebe.review.dto.ReviewSummaryResponse;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -42,6 +43,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final S3Service s3Service;
+    private final ApplicationEventPublisher eventPublisher;
 
     public List<ReviewResponse> getReviewsByPlaceId(Long placeId, AuthUser authUser) {
         Place place = placeRepository.findById(placeId)
@@ -111,8 +113,11 @@ public class ReviewService {
             }
         }
 
-        reviewRepository.save(review);
+        Review savedReview = reviewRepository.save(review);
         checkAndAddTagToPlace(tags, place);
+
+        AdminReviewResponse reviewResponse = AdminReviewResponse.from(savedReview);
+        eventPublisher.publishEvent(reviewResponse);
     }
 
     @Transactional

--- a/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
-public class AdminReviewController {
+public class AdminReviewController implements AdminReviewControllerSwagger {
 
     private final ReviewService reviewService;
     private final SseService sseService;

--- a/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
@@ -8,10 +8,12 @@ import org.example.sejonglifebe.user.Role;
 import org.example.sejonglifebe.review.ReviewService;
 import org.example.sejonglifebe.review.admin.dto.AdminReviewResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -21,6 +23,7 @@ import java.util.List;
 public class AdminReviewController {
 
     private final ReviewService reviewService;
+    private final SseService sseService;
 
     @LoginRequired(role = Role.ADMIN)
     @GetMapping("/reviews")
@@ -28,7 +31,7 @@ public class AdminReviewController {
         return CommonResponse.of(HttpStatus.OK, "리뷰 로그 목록 조회 성공", reviewService.findAllReviews());
     }
 
-    @LoginRequired
+    @LoginRequired(role = Role.ADMIN)
     @GetMapping(value = "/reviews/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter streamReviewLogs(AuthUser authUser) {
         String emitterId = "admin-" + authUser.studentId() + "-" + System.currentTimeMillis();

--- a/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewController.java
@@ -29,4 +29,11 @@ public class AdminReviewController {
     public ResponseEntity<CommonResponse<List<AdminReviewResponse>>> getAdminReviews(AuthUser authUser) {
         return CommonResponse.of(HttpStatus.OK, "리뷰 로그 목록 조회 성공", reviewService.findAllReviews());
     }
+
+    @LoginRequired
+    @GetMapping(value = "/reviews/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamReviewLogs(AuthUser authUser) {
+        String emitterId = "admin-" + authUser.studentId() + "-" + System.currentTimeMillis();
+        return sseService.subscribe(emitterId);
+    }
 }

--- a/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/AdminReviewControllerSwagger.java
@@ -1,0 +1,21 @@
+package org.example.sejonglifebe.review.admin;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.sejonglifebe.auth.AuthUser;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.review.admin.dto.AdminReviewResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+@Tag(name = "AdminReview", description = "관리자 리뷰 로그")
+public interface AdminReviewControllerSwagger {
+
+    @Operation(summary = "관리자 리뷰 목록 전체 조회")
+    ResponseEntity<CommonResponse<List<AdminReviewResponse>>> getAdminReviews(AuthUser authUser);
+
+    @Operation(summary = "관리자 리뷰 로그 SSE 연결")
+    public SseEmitter streamReviewLogs(AuthUser authUser);
+}

--- a/src/main/java/org/example/sejonglifebe/review/admin/ReviewLogEventListener.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/ReviewLogEventListener.java
@@ -1,0 +1,23 @@
+package org.example.sejonglifebe.review.admin;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sejonglifebe.review.admin.dto.AdminReviewResponse;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewLogEventListener {
+
+    private final SseService sseService;
+
+    @Async
+    @EventListener
+    public void handleReviewLogEvent(AdminReviewResponse reviewData) {
+        log.info("리뷰 생성 이벤트 수신: reviewId={}, placeName={}", reviewData.reviewId(), reviewData.placeName());
+        sseService.sendToAll("review-created", reviewData);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/review/admin/ReviewLogEventListener.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/ReviewLogEventListener.java
@@ -3,9 +3,10 @@ package org.example.sejonglifebe.review.admin;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.sejonglifebe.review.admin.dto.AdminReviewResponse;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -15,7 +16,7 @@ public class ReviewLogEventListener {
     private final SseService sseService;
 
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReviewLogEvent(AdminReviewResponse reviewData) {
         log.info("리뷰 생성 이벤트 수신: reviewId={}, placeName={}", reviewData.reviewId(), reviewData.placeName());
         sseService.sendToAll("review-created", reviewData);

--- a/src/main/java/org/example/sejonglifebe/review/admin/SseService.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/SseService.java
@@ -34,6 +34,7 @@ public class SseService {
         });
         emitter.onError((e) -> {
             log.error("SSE 연결 에러 : emitterId={}", emitterId, e);
+            emitter.complete();
             emitters.remove(emitterId);
         });
         try {
@@ -42,8 +43,8 @@ public class SseService {
                     .data("SSE 연결 성공")
                     .reconnectTime(RECONNECTION_TIMEOUT));
         } catch (IOException e) {
-            log.error("초기 메시지 전송 실패: emitterId={}", emitterId,
-                    e);
+            log.error("초기 메시지 전송 실패: emitterId={}", emitterId, e);
+            emitter.complete();
             emitters.remove(emitterId);
             throw new RuntimeException("SSE 연결 실패");
         }
@@ -59,6 +60,7 @@ public class SseService {
                         .reconnectTime(RECONNECTION_TIMEOUT));
             } catch (IOException e) {
                 log.error("SSE 메시지 전송 실패 : emitterId={}, event={}", id, eventName, e);
+                emitter.complete();
                 emitters.remove(id);
             }
         });

--- a/src/main/java/org/example/sejonglifebe/review/admin/SseService.java
+++ b/src/main/java/org/example/sejonglifebe/review/admin/SseService.java
@@ -1,0 +1,69 @@
+package org.example.sejonglifebe.review.admin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+public class SseService {
+
+    private final Long DEFAULT_TIMEOUT = 60 * 60 * 1000L;
+    private static final Long RECONNECTION_TIMEOUT = 3000L;
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter subscribe(String emitterId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitters.put(emitterId, emitter);
+
+        log.info("SSE 연결 생성 : emitterId={}", emitterId);
+
+        emitter.onCompletion(() -> {
+            log.info("SSE 연결 완료 : emitterId={}", emitterId);
+            emitters.remove(emitterId);
+        });
+        emitter.onTimeout(() -> {
+            log.warn("SSE 연결 타임아웃 : emitterId={}", emitterId);
+            emitter.complete();
+            emitters.remove(emitterId);
+        });
+        emitter.onError((e) -> {
+            log.error("SSE 연결 에러 : emitterId={}", emitterId, e);
+            emitters.remove(emitterId);
+        });
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("SSE 연결 성공")
+                    .reconnectTime(RECONNECTION_TIMEOUT));
+        } catch (IOException e) {
+            log.error("초기 메시지 전송 실패: emitterId={}", emitterId,
+                    e);
+            emitters.remove(emitterId);
+            throw new RuntimeException("SSE 연결 실패");
+        }
+        return emitter;
+    }
+
+    public void sendToAll(String eventName, Object data) {
+        emitters.forEach((id, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data)
+                        .reconnectTime(RECONNECTION_TIMEOUT));
+            } catch (IOException e) {
+                log.error("SSE 메시지 전송 실패 : emitterId={}, event={}", id, eventName, e);
+                emitters.remove(id);
+            }
+        });
+    }
+}
+
+
+

--- a/src/test/java/org/example/sejonglifebe/review/ReviewServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/review/ReviewServiceTest.java
@@ -60,6 +60,9 @@ class ReviewServiceTest {
     @Mock
     private S3Service s3Service;
 
+    @Mock
+    private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private ReviewService reviewService;
 
@@ -308,6 +311,12 @@ class ReviewServiceTest {
             given(userRepository.findByStudentId("21011111")).willReturn(Optional.of(user));
             given(placeRepository.findById(placeId)).willReturn(Optional.of(place));
             given(tagRepository.findByIdIn(request.tagIds())).willReturn(List.of(tag));
+            given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> {
+                Review review = invocation.getArgument(0);
+                ReflectionTestUtils.setField(review, "id", 1L);
+                ReflectionTestUtils.setField(review, "createdAt", java.time.LocalDateTime.now());
+                return review;
+            });
 
             // when
             reviewService.createReview(placeId, request, authUser, null);


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #93 

---

## 📝 주요 변경 내용

 - SSE 스트림 엔드포인트 추가(`GET /api/admin/reviews/stream`)
    - 관리자 전용 실시간 리뷰 로그 스트리밍
    - @LoginRequired(role = Role.ADMIN) 권한 체크

 - 비동기 이벤트 처리
    - AsyncConfig : 비동기 작업을 위한 ThreadPool 설정
    - ReviewLogEventListener : 리뷰 생성 이벤트를 비동기로 수신하여 SSE로 전송
    - ReviewService : 리뷰 저장 시 ApplicationEventPublisher 를 통해 이벤트 발행

-- 테스트 코드 작성
---

## 🛠️ 작업 상세 내역

### AsyncConfig (비동기 스레드 풀 설정)
  - Core Pool Size: 2: 관리자 페이지는 다수의 동시 접속이 발생할 가능성이 낮다고 판단했습니다.
  - Max Pool Size: 10: 트래픽 증가 시 확장 가능하도록 설정했습니다.
  - Queue Capacity: 100: 대기 큐 크기, 추후 모니터링을 통해 리뷰 생성 API 요청 빈도를 확인한 뒤 필요 시 조정이 필요해보입니다.
 
 ### 비동기 이벤트 처리
  - @Async와 @EventListener를 활용하여 리뷰 저장 트랜잭션과 SSE 전송을 분리하여 리뷰 생성이 이벤트 발행때문에 응답이 느려지거나 문제가 되는 상황을 피하도록 설계했습니다.

  관리자 전용 기능 분리
  - 유지보수 편의성을 위해 AdminReviewController를 별도로 생성했습니다.
  - @LoginRequired(role = Role.ADMIN)으로 권한 체크하도록 했습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---