### PR TITLE
feat: 장소 api 반환값 즐겨찾기 여부 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -38,14 +38,15 @@ public class PlaceController implements PlaceControllerSwagger {
 
     @GetMapping
     public ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
-            @Valid @ModelAttribute PlaceSearchConditions conditions) {
-        List<PlaceResponse> response = placeService.getPlaceByConditions(conditions);
+            @Valid @ModelAttribute PlaceSearchConditions conditions,
+            AuthUser authUser) {
+        List<PlaceResponse> response = placeService.getPlaceByConditions(conditions, authUser);
         return CommonResponse.of(HttpStatus.OK, "장소 목록 조회 성공", response);
     }
 
     @GetMapping("/hot")
-    public ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces() {
-        List<PlaceResponse> hotPlaceResponses = placeService.getWeeklyHotPlaces();
+    public ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces(AuthUser authUser) {
+        List<PlaceResponse> hotPlaceResponses = placeService.getWeeklyHotPlaces(authUser);
         return CommonResponse.of(HttpStatus.OK, "핫플레이스 조회 성공", hotPlaceResponses);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
@@ -23,10 +23,11 @@ public interface PlaceControllerSwagger {
 
     @Operation(summary = "장소 목록 조회")
     ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
-            @Valid @ModelAttribute PlaceSearchConditions conditions);
+            @Valid @ModelAttribute PlaceSearchConditions conditions,
+            AuthUser authUser);
 
     @Operation(summary = "주간 핫플레이스 조회")
-    ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces();
+    ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces(AuthUser authUser);
 
     @Operation(summary = "장소 상세 정보 조회")
     ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlaceDetail(

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceDetailResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceDetailResponse.java
@@ -7,6 +7,7 @@ import org.example.sejonglifebe.common.dto.CategoryInfo;
 import org.example.sejonglifebe.common.dto.TagInfo;
 import org.example.sejonglifebe.place.entity.MapLinks;
 import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.user.User;
 
 @Schema(description = "장소 상세 정보")
 public record PlaceDetailResponse(
@@ -18,10 +19,11 @@ public record PlaceDetailResponse(
         @Schema(description = "조회수", example = "12345") Long viewCount,
         @Schema(description = "지도 링크(카카오/네이버/구글 등)") MapLinks mapLinks,
         @Schema(description = "제휴 여부") boolean isPartnership,
-        @Schema(description = "제휴 내용") String partnershipContent
+        @Schema(description = "제휴 내용") String partnershipContent,
+        @Schema(description = "즐겨찾기 여부") boolean isFavorite
 ) {
 
-    public static PlaceDetailResponse from(Place place) {
+    public static PlaceDetailResponse from(Place place, User user) {
         return new PlaceDetailResponse(
                 place.getId(),
                 place.getName(),
@@ -37,7 +39,8 @@ public record PlaceDetailResponse(
                 place.getViewCount(),
                 place.getMapLinks(),
                 place.isPartnership(),
-                place.getPartnershipContent()
+                place.getPartnershipContent(),
+                user != null ? user.getFavoritePlaces().stream().anyMatch(fp -> fp.getPlace().equals(place)) : false
         );
     }
 }

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.sejonglifebe.common.dto.CategoryInfo;
 import org.example.sejonglifebe.common.dto.TagInfo;
 import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.user.User;
 
 @Schema(description = "장소 목록 아이템")
 public record PlaceResponse(
@@ -17,10 +18,11 @@ public record PlaceResponse(
         @Schema(description = "카테고리 목록") List<CategoryInfo> categories,
         @Schema(description = "태그 목록") List<TagInfo> tags,
         @Schema(description = "제휴 여부") boolean isPartnership,
-        @Schema(description = "제휴 내용") String partnershipContent
+        @Schema(description = "제휴 내용") String partnershipContent,
+        @Schema(description = "즐겨찾기 여부") boolean isFavorite
 ) {
 
-    public static PlaceResponse from(Place place) {
+    public static PlaceResponse from(Place place, User user) {
         return new PlaceResponse(
                 place.getId(),
                 place.getName(),
@@ -34,7 +36,8 @@ public record PlaceResponse(
                         .map(pt -> new TagInfo(pt.getTag().getId(), pt.getTag().getName()))
                         .toList(),
                 place.isPartnership(),
-                place.getPartnershipContent()
+                place.getPartnershipContent(),
+                user != null ? user.getFavoritePlaces().stream().anyMatch(fp -> fp.getPlace().equals(place)) : false
         );
     }
 }

--- a/src/main/java/org/example/sejonglifebe/place/favorite/FavoritePlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/favorite/FavoritePlaceService.java
@@ -1,6 +1,5 @@
 package org.example.sejonglifebe.place.favorite;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
@@ -13,6 +12,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,8 +25,12 @@ public class FavoritePlaceService {
 
     @Transactional(readOnly = true)
     public List<PlaceResponse> getMyFavorites(String studentId) {
-        return favoritePlaceRepository.findFavoritePlacesByStudentId(studentId).stream()
-                .map(PlaceResponse::from)
+        User user = userRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        return favoritePlaceRepository.findFavoritePlacesByStudentId(studentId)
+                .stream()
+                .map(place -> PlaceResponse.from(place , user))
                 .toList();
     }
 

--- a/src/main/java/org/example/sejonglifebe/user/User.java
+++ b/src/main/java/org/example/sejonglifebe/user/User.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.sejonglifebe.place.favorite.FavoritePlace;
 import org.example.sejonglifebe.review.Review;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -55,6 +56,10 @@ public class User {
     @Builder.Default
     @OneToMany(mappedBy = "user")
     private List<Review> reviews = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "user")
+    private List<FavoritePlace> favoritePlaces = new ArrayList<>();
 
     public void addReview(Review review) {
         reviews.add(review);

--- a/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
@@ -99,6 +99,7 @@ public class PlaceControllerTest {
         tagRepository.deleteAll();
         categoryRepository.deleteAll();
         placeViewLogRepository.deleteAll();
+        userRepository.deleteAll();
 
         Category category1 = new Category("식당");
         Category category2 = new Category("카페");
@@ -631,6 +632,27 @@ public class PlaceControllerTest {
         // then: DB 삭제 안 됨
         assertThat(placeRepository.count()).isEqualTo(beforeCount);
         assertThat(placeRepository.findById(placeId)).isPresent();
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자 장소 조회 시 isFavorite는 false")
+    void getPlaceList_asGuest_isFavoriteIsFalse() throws Exception {
+        mockMvc.perform(get("/api/places")
+                        .param("category", "전체")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].isFavorite").value(false))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자 장소 상세 조회 시 isFavorite는 false")
+    void getPlaceDetail_asGuest_isFavoriteIsFalse() throws Exception {
+        mockMvc.perform(get("/api/places/" + detailPlace.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.isFavorite").value(false))
+                .andDo(print());
     }
 
     private static String sha256Hex(String input) {

--- a/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
@@ -14,6 +14,7 @@ import org.example.sejonglifebe.place.view.PlaceViewLogRepository;
 import org.example.sejonglifebe.s3.S3Service;
 import org.example.sejonglifebe.tag.Tag;
 import org.example.sejonglifebe.tag.TagRepository;
+import org.example.sejonglifebe.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -53,6 +55,9 @@ class PlaceServiceTest {
     @Mock
     private S3Service s3Service;
 
+    @Mock
+    private UserRepository userRepository;
+
     @InjectMocks
     private PlaceService placeService;
 
@@ -70,7 +75,7 @@ class PlaceServiceTest {
                     .willReturn(List.of());
 
             // when/then
-            assertThatThrownBy(() -> placeService.getPlaceByConditions(conditions))
+            assertThatThrownBy(() -> placeService.getPlaceByConditions(conditions, null))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.TAG_NOT_FOUND.getErrorMessage());
 
@@ -90,7 +95,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1, place2));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(2);
@@ -111,7 +116,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(1);
@@ -128,7 +133,7 @@ class PlaceServiceTest {
             given(categoryRepository.findByName("맛집")).willReturn(Optional.empty());
 
             // then
-            assertThatThrownBy(() -> placeService.getPlaceByConditions(conditions))
+            assertThatThrownBy(() -> placeService.getPlaceByConditions(conditions, null))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.CATEGORY_NOT_FOUND.getErrorMessage());
         }
@@ -148,7 +153,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1, place2));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(2);
@@ -171,7 +176,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(1);
@@ -191,7 +196,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1, place2));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(2);
@@ -213,7 +218,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(1);
@@ -233,7 +238,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(1);
@@ -255,7 +260,7 @@ class PlaceServiceTest {
                     .willReturn(List.of(place1));
 
             // when
-            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions);
+            List<PlaceResponse> result = placeService.getPlaceByConditions(conditions, null);
 
             // then
             assertThat(result).hasSize(1);
@@ -287,6 +292,7 @@ class PlaceServiceTest {
             // given
             Place place = Place.builder().name("맛집").address("주소").mainImageUrl("url").build();
             given(placeRepository.findById(1L)).willReturn(Optional.of(place));
+            given(userRepository.findByStudentId(anyString())).willReturn(Optional.empty());
             MockHttpServletRequest request = new MockHttpServletRequest();
             MockHttpServletResponse response = new MockHttpServletResponse();
 

--- a/src/test/java/org/example/sejonglifebe/place/favorite/FavoritePlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/favorite/FavoritePlaceServiceTest.java
@@ -49,9 +49,14 @@ class FavoritePlaceServiceTest {
         void getMyFavorites_success() {
             // given
             String studentId = "21011111";
+            User user = User.builder().studentId(studentId).nickname("닉네임").build();
             Place place1 = Place.builder().name("장소1").address("주소1").mainImageUrl("url1").build();
             Place place2 = Place.builder().name("장소2").address("주소2").mainImageUrl("url2").build();
 
+            FavoritePlace fav1 = FavoritePlace.of(user, place1);
+            FavoritePlace fav2 = FavoritePlace.of(user, place2);
+
+            given(userRepository.findByStudentId(studentId)).willReturn(Optional.of(user));
             given(favoritePlaceRepository.findFavoritePlacesByStudentId(studentId))
                     .willReturn(List.of(place1, place2));
 
@@ -62,6 +67,7 @@ class FavoritePlaceServiceTest {
             assertThat(result).hasSize(2);
             assertThat(result.get(0).placeName()).isEqualTo("장소1");
             assertThat(result.get(1).placeName()).isEqualTo("장소2");
+            verify(userRepository).findByStudentId(studentId);
             verify(favoritePlaceRepository).findFavoritePlacesByStudentId(studentId);
         }
     }


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #119 

---

## 📝 주요 변경 내용

-  장소 조회 API 응답에 사용자의 즐겨찾기 여부(`isFavorite`) 필드를 추가했습니다.

---

## 🛠️ 작업 상세 내역

 - `PlaceResponse`, `PlaceDetailResponse`에 `isFavorite` 필드 추가
  - 장소 목록 조회, 핫플레이스 조회, 장소 상세 조회 API에 즐겨찾기 여부 포함
  - 로그인한 사용자: 실제 즐겨찾기 상태 반영
  - 비로그인 사용자: `isFavorite=false` 반환
  - `User` 엔티티에 `FavoritePlace` 관계 추가 
  - 관련 테스트 코드 작성

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 롤백된 코드 머지했습니다. 변경사항이 겹치는 부분이 PlaceService에 많아 해당 부분 위주로 잘못 머지된 곳이 있는지 확인 부탁드립니다!

---