### PR TITLE
feat: 장소 조회 페이지네이션 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/common/dto/PageResponse.java
+++ b/src/main/java/org/example/sejonglifebe/common/dto/PageResponse.java
@@ -1,0 +1,22 @@
+package org.example.sejonglifebe.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+public record PageResponse(
+        @Schema(example = "0") int page,
+        @Schema(example = "10") int size,
+        @Schema(example = "50") long totalElements,
+        @Schema(example = "5") int totalPages,
+        @Schema(example = "true") boolean hasNext
+) {
+    public static PageResponse from(Page<?> page) {
+        return new PageResponse(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/place/PlaceController.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceController.java
@@ -15,7 +15,9 @@ import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
+import org.example.sejonglifebe.place.dto.PlacePageResponse;
 import org.example.sejonglifebe.place.dto.PlaceResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,9 +39,10 @@ public class PlaceController implements PlaceControllerSwagger {
     private final FavoritePlaceService favoritePlaceService;
 
     @GetMapping
-    public ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
-            @Valid @ModelAttribute PlaceSearchConditions conditions) {
-        List<PlaceResponse> response = placeService.getPlaceByConditions(conditions);
+    public ResponseEntity<CommonResponse<PlacePageResponse>> getPlaces(
+            @Valid @ModelAttribute PlaceSearchConditions conditions,
+            Pageable pageable) {
+        PlacePageResponse response = PlacePageResponse.of(placeService.getPlaceByConditions(conditions, pageable));
         return CommonResponse.of(HttpStatus.OK, "장소 목록 조회 성공", response);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceControllerSwagger.java
@@ -10,6 +10,8 @@ import org.example.sejonglifebe.place.dto.PlaceDetailResponse;
 import org.example.sejonglifebe.place.dto.PlaceRequest;
 import org.example.sejonglifebe.place.dto.PlaceResponse;
 import org.example.sejonglifebe.place.dto.PlaceSearchConditions;
+import org.example.sejonglifebe.place.dto.PlacePageResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,8 +24,9 @@ import org.springframework.web.multipart.MultipartFile;
 public interface PlaceControllerSwagger {
 
     @Operation(summary = "장소 목록 조회")
-    ResponseEntity<CommonResponse<List<PlaceResponse>>> getPlaces(
-            @Valid @ModelAttribute PlaceSearchConditions conditions);
+    ResponseEntity<CommonResponse<PlacePageResponse>> getPlaces(
+            @Valid @ModelAttribute PlaceSearchConditions conditions,
+            Pageable pageable);
 
     @Operation(summary = "주간 핫플레이스 조회")
     ResponseEntity<CommonResponse<List<PlaceResponse>>> getHotPlaces();

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
@@ -1,16 +1,19 @@
 package org.example.sejonglifebe.place;
 
 import org.example.sejonglifebe.category.Category;
-import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.place.dto.PlaceQueryResult;
 import org.example.sejonglifebe.tag.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface PlaceRepositoryCustom {
 
-    List<Place> getPlacesByConditions(
+    Page<PlaceQueryResult> getPlacesByConditions(
             Category category,
             List<Tag> tags,
-            String keyword
+            String keyword,
+            Pageable pageable
     );
 }

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlacePageResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlacePageResponse.java
@@ -1,0 +1,18 @@
+package org.example.sejonglifebe.place.dto;
+
+import org.example.sejonglifebe.common.dto.PageResponse;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PlacePageResponse(
+        List<PlaceResponse> places,
+        PageResponse page
+) {
+    public static PlacePageResponse of(Page<PlaceResponse> page) {
+        return new PlacePageResponse(
+                page.getContent(),
+                PageResponse.from(page)
+        );
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceQueryResult.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceQueryResult.java
@@ -1,0 +1,9 @@
+package org.example.sejonglifebe.place.dto;
+
+import org.example.sejonglifebe.place.entity.Place;
+
+public record PlaceQueryResult(
+        Place place,
+        Long reviewCount
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceResponse.java
@@ -37,4 +37,23 @@ public record PlaceResponse(
                 place.getPartnershipContent()
         );
     }
+
+    public static PlaceResponse from(PlaceQueryResult result) {
+        Place place = result.place();
+        return new PlaceResponse(
+                place.getId(),
+                place.getName(),
+                place.getThumbnailImage(),
+                place.getViewCount(),
+                result.reviewCount(),
+                place.getPlaceCategories().stream()
+                        .map(pc -> new CategoryInfo(pc.getCategory().getId(), pc.getCategory().getName()))
+                        .toList(),
+                place.getPlaceTags().stream()
+                        .map(pt -> new TagInfo(pt.getTag().getId(), pt.getTag().getName()))
+                        .toList(),
+                place.isPartnership(),
+                place.getPartnershipContent()
+        );
+    }
 }

--- a/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
@@ -152,9 +152,9 @@ public class PlaceControllerTest {
                         .param("category", "전체")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(6))
-                .andExpect(jsonPath("$.data[0].viewCount").value(0))
-                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
+                .andExpect(jsonPath("$.data.places.length()").value(6))
+                .andExpect(jsonPath("$.data.places[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[0].reviewCount").value(0))
                 .andDo(print());
     }
 
@@ -168,12 +168,12 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data.places.length()").value(1))
 
                 // 정렬 순서 검증
-                .andExpect(jsonPath("$.data[0].placeName").value("식당3")) // 두 번째 결과는 '식당1'
-                .andExpect(jsonPath("$.data[0].viewCount").value(0))
-                .andExpect(jsonPath("$.data[0].reviewCount").value(0));
+                .andExpect(jsonPath("$.data.places[0].placeName").value("식당3"))
+                .andExpect(jsonPath("$.data.places[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[0].reviewCount").value(0));
     }
 
     @Test
@@ -184,16 +184,16 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(3))
-                .andExpect(jsonPath("$.data[0].placeName").value("식당1"))
-                .andExpect(jsonPath("$.data[0].viewCount").value(0))
-                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
-                .andExpect(jsonPath("$.data[1].placeName").value("식당2"))
-                .andExpect(jsonPath("$.data[1].viewCount").value(0))
-                .andExpect(jsonPath("$.data[1].reviewCount").value(0))
-                .andExpect(jsonPath("$.data[2].placeName").value("식당3"))
-                .andExpect(jsonPath("$.data[2].viewCount").value(0))
-                .andExpect(jsonPath("$.data[2].reviewCount").value(0));
+                .andExpect(jsonPath("$.data.places.length()").value(3))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("식당1"))
+                .andExpect(jsonPath("$.data.places[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[0].reviewCount").value(0))
+                .andExpect(jsonPath("$.data.places[1].placeName").value("식당2"))
+                .andExpect(jsonPath("$.data.places[1].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[1].reviewCount").value(0))
+                .andExpect(jsonPath("$.data.places[2].placeName").value("식당3"))
+                .andExpect(jsonPath("$.data.places[2].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[2].reviewCount").value(0));
     }
 
     @Test
@@ -205,13 +205,13 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].placeName").value("카페1"))
-                .andExpect(jsonPath("$.data[0].viewCount").value(0))
-                .andExpect(jsonPath("$.data[0].reviewCount").value(0))
-                .andExpect(jsonPath("$.data[1].placeName").value("카페3"))
-                .andExpect(jsonPath("$.data[1].viewCount").value(0))
-                .andExpect(jsonPath("$.data[1].reviewCount").value(0));
+                .andExpect(jsonPath("$.data.places.length()").value(2))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("카페1"))
+                .andExpect(jsonPath("$.data.places[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[0].reviewCount").value(0))
+                .andExpect(jsonPath("$.data.places[1].placeName").value("카페3"))
+                .andExpect(jsonPath("$.data.places[1].viewCount").value(0))
+                .andExpect(jsonPath("$.data.places[1].reviewCount").value(0));
     }
 
     @Test
@@ -249,10 +249,10 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(3))
-                .andExpect(jsonPath("$.data[0].placeName").value("식당1"))
-                .andExpect(jsonPath("$.data[1].placeName").value("식당2"))
-                .andExpect(jsonPath("$.data[2].placeName").value("식당3"))
+                .andExpect(jsonPath("$.data.places.length()").value(3))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("식당1"))
+                .andExpect(jsonPath("$.data.places[1].placeName").value("식당2"))
+                .andExpect(jsonPath("$.data.places[2].placeName").value("식당3"))
                 .andDo(print());
     }
 
@@ -265,8 +265,8 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].placeName").value("카페1"))
+                .andExpect(jsonPath("$.data.places.length()").value(1))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("카페1"))
                 .andDo(print());
     }
 
@@ -280,8 +280,8 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].placeName").value("식당1"))
+                .andExpect(jsonPath("$.data.places.length()").value(1))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("식당1"))
                 .andDo(print());
     }
 
@@ -295,8 +295,8 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].placeName").value("카페3"))
+                .andExpect(jsonPath("$.data.places.length()").value(1))
+                .andExpect(jsonPath("$.data.places[0].placeName").value("카페3"))
                 .andDo(print());
     }
 
@@ -309,7 +309,7 @@ public class PlaceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(0))
+                .andExpect(jsonPath("$.data.places.length()").value(0))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #132 

---

## 📝 주요 변경 내용

- 장소 목록 조회 API에 오프셋 기반 페이지네이션 적용했습니다.

---

## 🛠️ 작업 상세 내역

  - QueryDSL에 offset/limit 적용 및 카운트 쿼리 분리했습니다.
  - PlaceQueryResult DTO 추가 - QueryDSL에서 Place + reviewCount (db에서 count 바로 조회) 집계하여 N+1 문제 해결했습니다.
  - PlaceResponse에 from(PlaceQueryResult) 팩토리 메서드 추가했습니다.
  - PlacePageResponse, PageResponse 커스텀 응답 DTO 구현했습니다.(필요한 페이지 정보만 반환하기위해서 Spring Page를 사용하지 않았습니다)
  - PageResponse 필드에 @Schema 예시값 추가했습니다.
---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---