### PR TITLE
feat: 제휴 필터링 방식 변경으로 페이지 개수 불일치 문제 수정

### DIFF
--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
@@ -14,6 +14,7 @@ public interface PlaceRepositoryCustom {
             Category category,
             List<Tag> tags,
             String keyword,
+            boolean partnershipOnly,
             Pageable pageable
     );
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.example.sejonglifebe.place;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -26,7 +27,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, Pageable pageable) {
+    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, boolean partnershipOnly, Pageable pageable) {
         JPAQuery<PlaceQueryResult> query = queryFactory
                 .select(Projections.constructor(PlaceQueryResult.class,
                         place,
@@ -46,7 +47,8 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 .leftJoin(place.reviews, review)
                 .where(likePlaceName(keyword),
                         placeCategoryEq(category),
-                        placeTagIn(tags)
+                        placeTagIn(tags),
+                        filterByPartnership(partnershipOnly)
                 )
                 .groupBy(place.id)
                 .having(placeTagCountEq(tags))
@@ -62,7 +64,8 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 .leftJoin(place.placeTags, placeTag)
                 .where(likePlaceName(keyword),
                         placeCategoryEq(category),
-                        placeTagIn(tags)
+                        placeTagIn(tags),
+                        filterByPartnership(partnershipOnly)
                 )
                 .fetchOne();
 
@@ -88,6 +91,13 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
             return null;
         }
         return placeTag.tag.in(tags);
+    }
+
+    private Predicate filterByPartnership(boolean partnershipOnly) {
+        if(!partnershipOnly){
+            return null;
+        }
+        return place.isPartnership.isTrue();
     }
 
     private BooleanExpression placeTagCountEq(List<Tag> tags) {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -1,13 +1,6 @@
 package org.example.sejonglifebe.place;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.Duration;
-import java.time.LocalDateTime;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthUser;
 import org.example.sejonglifebe.category.Category;
@@ -39,6 +32,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class PlaceService {
@@ -54,6 +53,7 @@ public class PlaceService {
     public Page<PlaceResponse> getPlaceByConditions(PlaceSearchConditions conditions, Pageable pageable) {
         List<String> tagNames = conditions.tags();
         String categoryName = conditions.category();
+        boolean PartnershipOnly = conditions.partnershipOnly();
 
         Category category = null;
 
@@ -72,7 +72,7 @@ public class PlaceService {
                     .orElseThrow(() -> new SejongLifeException(ErrorCode.CATEGORY_NOT_FOUND));
         }
 
-        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), pageable)
+        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, pageable)
                 .map(PlaceResponse::from);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
@@ -17,6 +17,9 @@ public record PlaceSearchConditions(
         String category,
 
         @Schema(description = "검색어", example = "깍뚝")
-        String keyword
+        String keyword,
+
+        @Schema(description = "제휴 장소 필터링 여부" , example = "false")
+        boolean partnershipOnly
 ) {
 }

--- a/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceControllerTest.java
@@ -90,6 +90,7 @@ public class PlaceControllerTest {
 
     private Place detailPlace;
     private Place place1, place2, place3, place4, place5, place6; // 테스트에서 사용하기 위해 필드로 선언
+    private Place partnerPlace1, partnerPlace2; // 제휴 장소
 
     @BeforeEach
     void setUp() {
@@ -149,6 +150,7 @@ public class PlaceControllerTest {
     public void search_noCategory_noTags() throws Exception {
         mockMvc.perform(get("/api/places")
                         .param("category", "전체")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.places.length()").value(6))
@@ -164,6 +166,7 @@ public class PlaceControllerTest {
                         .param("category", "전체")
                         .param("tags", "맛집")
                         .param("tags", "가성비")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -180,6 +183,7 @@ public class PlaceControllerTest {
     public void search_categoryRestaurant_noTags() throws Exception {
         mockMvc.perform(get("/api/places")
                         .param("category", "식당")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -201,6 +205,7 @@ public class PlaceControllerTest {
         mockMvc.perform(get("/api/places")
                         .param("category", "카페")
                         .param("tags", "분위기 좋은")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -218,6 +223,7 @@ public class PlaceControllerTest {
     void search_wrongCategory_fail() throws Exception {
         mockMvc.perform(get("/api/places")
                         .param("category", "병원")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isNotFound())
@@ -232,6 +238,7 @@ public class PlaceControllerTest {
                         .param("category", "전체")
                         .param("tags", "맛집")
                         .param("tags", "진상부리기 좋은")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isNotFound())
@@ -245,6 +252,7 @@ public class PlaceControllerTest {
         mockMvc.perform(get("/api/places")
                         .param("category", "전체")
                         .param("keyword", "식당")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -261,6 +269,7 @@ public class PlaceControllerTest {
         mockMvc.perform(get("/api/places")
                         .param("category", "카페")
                         .param("keyword", "카페1")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -276,6 +285,7 @@ public class PlaceControllerTest {
                         .param("category", "전체")
                         .param("tags", "맛집")
                         .param("keyword", "식당1")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -291,6 +301,7 @@ public class PlaceControllerTest {
                         .param("category", "카페")
                         .param("tags", "분위기 좋은")
                         .param("keyword", "카페3")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -305,6 +316,7 @@ public class PlaceControllerTest {
         mockMvc.perform(get("/api/places")
                         .param("category", "전체")
                         .param("keyword", "존재하지않는장소")
+                        .param("partnershipOnly", "false")
                         .contentType(MediaType.APPLICATION_JSON))
 
                 .andExpect(status().isOk())
@@ -636,6 +648,54 @@ public class PlaceControllerTest {
         // then: DB 삭제 안 됨
         assertThat(placeRepository.count()).isEqualTo(beforeCount);
         assertThat(placeRepository.findById(placeId)).isPresent();
+    }
+
+    @Test
+    @DisplayName("partnershipOnly=true 이면 제휴 장소만 조회된다")
+    void search_partnershipOnly_true() throws Exception {
+        // given
+        Category category = categoryRepository.findByName("식당")
+                .orElseThrow(() -> new IllegalStateException("식당 카테고리가 없습니다."));
+        Tag tag = tagRepository.findByName("맛집")
+                .orElseThrow(() -> new IllegalStateException("맛집 태그가 없습니다."));
+
+        Place partnerPlace = Place.createPlace("제휴식당", "제휴주소", 127.0, 37.0, null, true, "10% 할인");
+        partnerPlace.addCategory(category);
+        partnerPlace.addTag(tag);
+        placeRepository.save(partnerPlace);
+
+        // when & then
+        mockMvc.perform(get("/api/places")
+                        .param("category", "전체")
+                        .param("partnershipOnly", "true")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.places.length()").value(1))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("partnershipOnly=false 이면 제휴 여부 관계없이 모든 장소가 조회된다")
+    void search_partnershipOnly_false_withPartnerPlace() throws Exception {
+        // given
+        Category category = categoryRepository.findByName("식당")
+                .orElseThrow(() -> new IllegalStateException("식당 카테고리가 없습니다."));
+        Tag tag = tagRepository.findByName("맛집")
+                .orElseThrow(() -> new IllegalStateException("맛집 태그가 없습니다."));
+
+        Place partnerPlace = Place.createPlace("제휴식당", "제휴주소", 127.0, 37.0, null, true, "10% 할인");
+        partnerPlace.addCategory(category);
+        partnerPlace.addTag(tag);
+        placeRepository.save(partnerPlace);
+
+        // when & then
+        mockMvc.perform(get("/api/places")
+                        .param("category", "전체")
+                        .param("partnershipOnly", "false")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.places.length()").value(7)) // 기존 6개 + 제휴 1개
+                .andDo(print());
     }
 
     private static String sha256Hex(String input) {

--- a/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
@@ -1,7 +1,6 @@
 package org.example.sejonglifebe.place;
 
 import org.example.sejonglifebe.auth.AuthUser;
-import org.example.sejonglifebe.user.Role;
 import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.category.CategoryRepository;
 import org.example.sejonglifebe.exception.ErrorCode;
@@ -15,6 +14,7 @@ import org.example.sejonglifebe.place.view.PlaceViewLogRepository;
 import org.example.sejonglifebe.s3.S3Service;
 import org.example.sejonglifebe.tag.Tag;
 import org.example.sejonglifebe.tag.TagRepository;
+import org.example.sejonglifebe.user.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,10 +29,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -69,7 +69,7 @@ class PlaceServiceTest {
         @DisplayName("존재하지 않는 태그 이름이 포함되면 TAG_NOT_FOUND 예외를 던진다")
         void getPlaces_tagNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null, false);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(anyList()))
@@ -87,7 +87,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 = 전체 && 태그 없음 → 모든 장소를 조회한다")
         void getPlaces_allCategory_noTags() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null, false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("장소1").build();
             Place place2 = Place.builder().name("장소2").build();
@@ -97,7 +97,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -114,13 +114,13 @@ class PlaceServiceTest {
         void getPlaces_allCategory_withTags() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null, false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 장소").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -135,7 +135,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 존재하지 않으면 CATEGORY_NOT_FOUND 예외를 던진다")
         void getPlaces_categoryNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
@@ -152,7 +152,7 @@ class PlaceServiceTest {
         void getPlaces_selectedCategory_noTags() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("맛집1").build();
             Place place2 = Place.builder().name("맛집2").build();
@@ -163,7 +163,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -181,14 +181,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null, false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 맛집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -203,7 +203,7 @@ class PlaceServiceTest {
         @DisplayName("키워드만 입력 → 장소명에 키워드가 포함된 장소를 조회한다")
         void getPlaces_withKeywordOnly() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페");
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페", false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("스타벅스 카페").build();
             Place place2 = Place.builder().name("투썸 카페").build();
@@ -213,7 +213,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -230,14 +230,14 @@ class PlaceServiceTest {
         void getPlaces_withCategoryAndKeyword() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨");
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨", false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("BHC 치킨").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -253,13 +253,13 @@ class PlaceServiceTest {
         void getPlaces_withTagAndKeyword() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자");
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자", false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 피자").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -276,14 +276,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨");
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨", false);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 치킨집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, pageable))
                     .willReturn(pageResult);
 
             // when


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #134 

---

## 📝 주요 변경 내용

# 문제 상황
제휴 필터링 조건을 프론트에서 처리하다보니 페이지네이션 데이터 개수가 맞지 않는 문제가 발생했습니다.
<img width="1096" height="493" alt="image" src="https://github.com/user-attachments/assets/fe1cb99b-b9e2-4422-b2ff-21cd988b9bad" />

# 해결 방법
  - Partnership 필터링 로직을 프론트엔드에서 백엔드로 이전했습니다.
  - QueryDSL의 `filterByPartnership()` 메서드를 추가하여 DB 레벨에서 제휴 여부를 필터링하도록 구현했습니다.
---

## 🛠️ 작업 상세 내역

 - PlaceSearchConditions: partnershipOnly 필드 추가
 - PlaceRepositoryCustom: 인터페이스에 partnershipOnly 파라미터 추가
 - PlaceRepositoryImpl:
    - filterByPartnership() 메서드로 제휴 여부 필터링 구현
    - content 쿼리와 total count 쿼리 모두에 동일한 필터 조건 적용
- 제휴 필터링 로직 관련 테스트 코드 작성
---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---