### PR TITLE
feat: 미팅 서비스 카카오 로그인 및 회원가입 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
+++ b/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
@@ -62,4 +62,14 @@ public class LoginResponse {
                 .userInfo(UserInfo.from(portalInfo))
                 .build();
     }
+
+    /**
+     * 미팅 신규 회원일 때 : 회원가입 필요, sign-up token 발급 (추가 정보 없음)
+     */
+    public static LoginResponse signUpRequired(String signUpToken) {
+        return LoginResponse.builder()
+                .isNewUser(true)
+                .signUpToken(signUpToken)
+                .build();
+    }
 }

--- a/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
@@ -68,6 +68,64 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    // 미팅 회원가입용 임시 토큰 (카카오 ID만 포함)
+    public String createMeetingSignUpToken(String kakaoId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + signUpTokenExpirationTime);
+
+        return Jwts.builder()
+                .subject(kakaoId)
+                .claim("type", "meeting_signup")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    // 미팅용 최종 JWT 토큰 생성
+    public String createMeetingToken(String kakaoId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expirationTime);
+
+        return Jwts.builder()
+                .subject(kakaoId)
+                .claim("type", "meeting")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    // 미팅 회원가입 토큰 검증 및 카카오 ID 추출
+    public String validateMeetingSignUpToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            String type = claims.get("type", String.class);
+            if (!"meeting_signup".equals(type)) {
+                throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+            }
+
+            return claims.getSubject();
+
+        } catch (ExpiredJwtException e) {
+            throw new SejongLifeException(ErrorCode.EXPIRED_TOKEN);
+
+        } catch (MalformedJwtException e) {
+            throw new SejongLifeException(ErrorCode.MALFORMED_TOKEN);
+
+        } catch (SignatureException e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+
+        } catch (Exception e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
     public PortalStudentInfo validateAndGetPortalInfo(String token) {
         try {
             Claims claims = Jwts.parser()

--- a/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
+++ b/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
@@ -41,7 +41,8 @@ public enum ErrorCode {
     KAKAO_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패했습니다."),
     ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "유효하지 않은 성별입니다."),
-    INVALID_FACE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 얼굴상입니다.");
+    INVALID_FACE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 얼굴상입니다."),
+    INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth State입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
+++ b/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
@@ -36,7 +36,13 @@ public enum ErrorCode {
     S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제 중 오류가 발생했습니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "리뷰 수정, 삭제 권한이 없습니다"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    ALREADY_FAVORITE_PLACE(HttpStatus.BAD_REQUEST, "이미 즐겨찾기로 등록된 장소입니다.");
+    ALREADY_FAVORITE_PLACE(HttpStatus.BAD_REQUEST, "이미 즐겨찾기로 등록된 장소입니다."),
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 토큰 발급에 실패했습니다."),
+    KAKAO_USER_INFO_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패했습니다."),
+    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
+    INVALID_GENDER(HttpStatus.BAD_REQUEST, "유효하지 않은 성별입니다."),
+    INVALID_FACE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 얼굴상입니다.");
+
     private final HttpStatus httpStatus;
     private final String errorMessage;
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
@@ -1,12 +1,16 @@
 package org.example.sejonglifebe.meeting.controller;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.dto.CommonResponse;
 import org.example.sejonglifebe.common.jwt.JwtTokenExtractor;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.KakaoLoginRequest;
 import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.example.sejonglifebe.meeting.dto.StateResponse;
 import org.example.sejonglifebe.meeting.service.KakaoLoginService;
 import org.example.sejonglifebe.meeting.service.MeetingSignUpService;
 import org.springframework.http.HttpStatus;
@@ -14,6 +18,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Parameter;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/meeting/auth")
@@ -25,9 +31,24 @@ public class MeetingAuthController implements MeetingAuthControllerSwagger{
     private final MeetingSignUpService meetingSignUpService;
     private final JwtTokenExtractor jwtTokenExtractor;
 
+    @GetMapping("/kakao/state")
+    public ResponseEntity<CommonResponse<StateResponse>> createOAuthState(HttpSession session) {
+        String state = UUID.randomUUID().toString();
+        session.setAttribute("oauth_state", state);
+        return CommonResponse.of(HttpStatus.OK, "State 생성 완료", new StateResponse(state));
+    }
+
     @PostMapping("/kakao/login")
     public ResponseEntity<CommonResponse<LoginResponse>> kakaoLogin(
-            @Valid @RequestBody KakaoLoginRequest request) {
+            @Valid @RequestBody KakaoLoginRequest request,
+            HttpSession session) {
+
+        String savedState = (String) session.getAttribute("oauth_state");
+        if (savedState == null || !savedState.equals(request.getState())) {
+            throw new SejongLifeException(ErrorCode.INVALID_OAUTH_STATE);
+        }
+        session.removeAttribute("oauth_state");
+
         LoginResponse response = kakaoLoginService.loginWithKakao(request.getCode());
         return CommonResponse.of(HttpStatus.OK, "카카오 로그인 성공", response);
     }

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
@@ -1,0 +1,46 @@
+package org.example.sejonglifebe.meeting.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenExtractor;
+import org.example.sejonglifebe.meeting.dto.KakaoLoginRequest;
+import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.example.sejonglifebe.meeting.service.KakaoLoginService;
+import org.example.sejonglifebe.meeting.service.MeetingSignUpService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+@RestController
+@RequestMapping("/api/meeting/auth")
+@RequiredArgsConstructor
+
+public class MeetingAuthController implements MeetingAuthControllerSwagger{
+
+    private final KakaoLoginService kakaoLoginService;
+    private final MeetingSignUpService meetingSignUpService;
+    private final JwtTokenExtractor jwtTokenExtractor;
+
+    @PostMapping("/kakao/login")
+    public ResponseEntity<CommonResponse<LoginResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request) {
+        LoginResponse response = kakaoLoginService.loginWithKakao(request.getCode());
+        return CommonResponse.of(HttpStatus.OK, "카카오 로그인 성공", response);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponse<LoginResponse>> signUp(
+            @Parameter(description = "회원가입용 임시 토큰", required = true)
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody MeetingSignUpRequest request) {
+
+        String signUpToken = jwtTokenExtractor.extractToken(authHeader);
+
+        LoginResponse response = meetingSignUpService.signUp(signUpToken, request);
+        return CommonResponse.of(HttpStatus.CREATED, "회원가입 완료", response);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
@@ -1,0 +1,34 @@
+package org.example.sejonglifebe.meeting.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.meeting.dto.KakaoLoginRequest;
+import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Meeting Auth", description = "미팅 서비스 인증 (카카오 로그인)")
+public interface MeetingAuthControllerSwagger {
+
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 인가 코드를 받아 로그인 처리합니다. 신규 사용자는 signUpToken을 반환하고 기존 사용자는 accessToken을 반환합니다."
+    )
+    ResponseEntity<CommonResponse<LoginResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request);
+
+
+    @Operation(
+            summary = "미팅 회원가입",
+            description = "signUpToken과 함께 추가 정보를 입력받아 회원가입을 완료하고 최종 JWT 토큰을 반환합니다."
+    )
+    ResponseEntity<CommonResponse<LoginResponse>> signUp(
+            @Parameter(description = "회원가입용 임시 토큰", required = true)
+            @RequestHeader("Authorization") String authHeader,
+            @Valid @RequestBody MeetingSignUpRequest request);
+
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
@@ -3,11 +3,13 @@ package org.example.sejonglifebe.meeting.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.dto.CommonResponse;
 import org.example.sejonglifebe.meeting.dto.KakaoLoginRequest;
 import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.example.sejonglifebe.meeting.dto.StateResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,10 +18,16 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface MeetingAuthControllerSwagger {
 
     @Operation(
+            summary = "OAuth State 생성",
+            description = "카카오 로그인 시 CSRF 방지를 위한 State 값을 생성합니다."
+    )
+    ResponseEntity<CommonResponse<StateResponse>> createOAuthState(HttpSession session);
+
+    @Operation(
             summary = "카카오 로그인",
             description = "카카오 인가 코드를 받아 로그인 처리합니다. 신규 사용자는 signUpToken을 반환하고 기존 사용자는 accessToken을 반환합니다."
     )
-    ResponseEntity<CommonResponse<LoginResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request);
+    ResponseEntity<CommonResponse<LoginResponse>> kakaoLogin(@Valid @RequestBody KakaoLoginRequest request, HttpSession session);
 
 
     @Operation(

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoLoginRequest.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoLoginRequest.java
@@ -10,4 +10,7 @@ public class KakaoLoginRequest {
 
     @NotBlank(message = "인가 코드는 필수입니다.")
     private String code;
+
+    @NotBlank(message = "State는 필수입니다.")
+    private String state;
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoLoginRequest.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoLoginRequest.java
@@ -1,0 +1,13 @@
+package org.example.sejonglifebe.meeting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginRequest {
+
+    @NotBlank(message = "인가 코드는 필수입니다.")
+    private String code;
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoTokenResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoTokenResponse.java
@@ -1,0 +1,15 @@
+package org.example.sejonglifebe.meeting.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    private String access_token;
+    private String token_type;
+    private Integer expires_in;
+    private String refresh_token;
+    private Integer refresh_token_expires_in;
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoUserInfo.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/KakaoUserInfo.java
@@ -1,0 +1,11 @@
+package org.example.sejonglifebe.meeting.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+    private Long id;
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingSignUpRequest.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingSignUpRequest.java
@@ -1,0 +1,29 @@
+package org.example.sejonglifebe.meeting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.sejonglifebe.meeting.entity.FaceType;
+import org.example.sejonglifebe.meeting.entity.Gender;
+
+public record MeetingSignUpRequest(
+        @NotNull(message = "성별은 필수입니다.")
+        Gender gender,
+
+        @NotNull(message = "얼굴상은 필수입니다.")
+        FaceType faceType,
+
+        @NotNull(message = "출생년도는 필수입니다.")
+        Integer birthYear,
+
+        @NotBlank(message = "취미는 필수입니다.")
+        String hobby,
+
+        @NotBlank(message = "하고싶은 데이트는 필수입니다.")
+        String dateStyle,
+
+        String appeal,
+
+        @NotBlank(message = "연락처는 필수입니다.")
+        String contact
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/StateResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/StateResponse.java
@@ -1,0 +1,9 @@
+package org.example.sejonglifebe.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StateResponse(
+        @Schema(description = "CSRF 방지용 State 값", example = "550e8400-e29b-41d4-a716-446655440000")
+        String state
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/FaceType.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/FaceType.java
@@ -1,0 +1,31 @@
+package org.example.sejonglifebe.meeting.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+
+@Getter
+@RequiredArgsConstructor
+public enum FaceType {
+    DOG("강아지상"),
+    CAT("고양이상"),
+    RABBIT("토끼상"),
+    BEAR("곰상"),
+    DEER("사슴상"),
+    FOX("여우상"),
+    DINOSAUR("공룡상");
+
+    private final String description;
+
+    @JsonCreator
+    public static FaceType from(String value) {
+        for (FaceType faceType : FaceType.values()) {
+            if (faceType.name().equals(value)) {
+                return faceType;
+            }
+        }
+        throw new SejongLifeException(ErrorCode.INVALID_FACE_TYPE);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/Gender.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/Gender.java
@@ -1,0 +1,26 @@
+package org.example.sejonglifebe.meeting.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("남"),
+    FEMALE("여");
+
+    private final String description;
+
+    @JsonCreator
+    public static Gender from(String value) {
+        for (Gender gender : Gender.values()) {
+            if (gender.name().equals(value)) {
+                return gender;
+            }
+        }
+        throw new SejongLifeException(ErrorCode.INVALID_GENDER);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
@@ -1,0 +1,57 @@
+package org.example.sejonglifebe.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "meeting_profiles")
+public class MeetingProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_profile_id")
+    private Long id;
+
+    @Column(name = "kakao_id", unique = true, nullable = false)
+    private String kakaoId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false, length = 10)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "face_type", nullable = false, length = 20)
+    private FaceType faceType;
+
+    @Column(name = "birth_year", nullable = false)
+    private Integer birthYear;
+
+    @Column(name = "hobby", nullable = false, length = 50)
+    private String hobby;
+
+    @Column(name = "date_style", nullable = false, length = 100)
+    private String dateStyle;
+
+    @Column(name = "appeal", columnDefinition = "TEXT")
+    private String appeal;
+
+    @Column(name = "contact", nullable = false, length = 100)
+    private String contact;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/oauth/KakaoOAuthClient.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/oauth/KakaoOAuthClient.java
@@ -1,0 +1,69 @@
+package org.example.sejonglifebe.meeting.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.sejonglifebe.meeting.dto.KakaoTokenResponse;
+import org.example.sejonglifebe.meeting.dto.KakaoUserInfo;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+public class KakaoOAuthClient {
+
+    private final WebClient webClient;
+    private final KakaoOAuthProperties properties;
+
+    public KakaoOAuthClient(@Qualifier("kakaoWebClient") WebClient webClient, KakaoOAuthProperties properties) {
+        this.webClient = webClient;
+        this.properties = properties;
+    }
+
+    /**
+     * 카카오 인가 코드를 액세스 토큰으로 교환
+     */
+    public KakaoTokenResponse getAccessToken(String code) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", properties.getClientId());
+        formData.add("client_secret", properties.getClientSecret());
+        formData.add("redirect_uri", properties.getRedirectUri());
+        formData.add("code", code);
+
+        try {
+            return webClient.post()
+                    .uri(properties.getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue(formData)
+                    .retrieve()
+                    .bodyToMono(KakaoTokenResponse.class)
+                    .block();
+        } catch (Exception e) {
+            log.error("카카오 토큰 발급 실패", e);
+            throw new SejongLifeException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    /**
+     * 카카오 액세스 토큰으로 사용자 정보 조회
+     */
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        try {
+            return webClient.get()
+                    .uri(properties.getUserInfoUri())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfo.class)
+                    .block();
+        } catch (Exception e) {
+            log.error("카카오 사용자 정보 조회 실패", e);
+            throw new SejongLifeException(ErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/oauth/KakaoOAuthProperties.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/oauth/KakaoOAuthProperties.java
@@ -1,0 +1,19 @@
+package org.example.sejonglifebe.meeting.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "oauth.kakao")
+@Getter
+@Setter
+public class KakaoOAuthProperties {
+
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String tokenUri;
+    private String userInfoUri;
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
@@ -1,0 +1,13 @@
+package org.example.sejonglifebe.meeting.repository;
+
+import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, Long> {
+
+    Optional<MeetingProfile> findByKakaoId(String kakaoId);
+
+    boolean existsByKakaoId(String kakaoId);
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/KakaoLoginService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/KakaoLoginService.java
@@ -1,0 +1,51 @@
+package org.example.sejonglifebe.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.dto.KakaoTokenResponse;
+import org.example.sejonglifebe.meeting.dto.KakaoUserInfo;
+import org.example.sejonglifebe.meeting.oauth.KakaoOAuthClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final MeetingProfileRepository meetingProfileRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public LoginResponse loginWithKakao(String code) {
+        // 1. 인가 코드로 카카오 액세스 토큰 발급
+        KakaoTokenResponse tokenResponse = kakaoOAuthClient.getAccessToken(code);
+
+        // 2. 액세스 토큰으로 카카오 사용자 정보 조회
+        KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(tokenResponse.getAccess_token());
+
+        // 3. 카카오 ID 생성
+        String kakaoId = "kakao_" + kakaoUserInfo.getId();
+
+        // 4. MeetingProfile 확인
+        Optional<MeetingProfile> profileOptional = meetingProfileRepository.findByKakaoId(kakaoId);
+
+        if (profileOptional.isPresent()) {
+            // 이미 회원가입 완료: 미팅 JWT 발급
+            String accessToken = jwtTokenProvider.createMeetingToken(kakaoId);
+            return LoginResponse.loginSuccess(accessToken);
+
+        } else {
+            // 신규 사용자: 회원가입용 임시 토큰 발급
+            String signUpToken = jwtTokenProvider.createMeetingSignUpToken(kakaoId);
+            return LoginResponse.signUpRequired(signUpToken);
+        }
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -1,0 +1,51 @@
+package org.example.sejonglifebe.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MeetingSignUpService {
+
+    private final MeetingProfileRepository meetingProfileRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public LoginResponse signUp(String signUpToken, MeetingSignUpRequest request) {
+        // 1. signUpToken 검증 및 kakaoId 추출
+        String kakaoId = jwtTokenProvider.validateMeetingSignUpToken(signUpToken);
+
+        // 2. 이미 가입된 사용자인지 확인
+        if (meetingProfileRepository.existsByKakaoId(kakaoId)) {
+            throw new SejongLifeException(ErrorCode.ALREADY_EXIST_USER);
+        }
+
+        // 3. MeetingProfile 생성 및 저장
+        MeetingProfile meetingProfile = MeetingProfile.builder()
+                .kakaoId(kakaoId)
+                .gender(request.gender())
+                .faceType(request.faceType())
+                .birthYear(request.birthYear())
+                .hobby(request.hobby())
+                .dateStyle(request.dateStyle())
+                .appeal(request.appeal())
+                .contact(request.contact())
+                .build();
+
+        meetingProfileRepository.save(meetingProfile);
+
+        // 4. 최종 JWT 토큰 발급 (미팅 전용)
+        String accessToken = jwtTokenProvider.createMeetingToken(kakaoId);
+        return LoginResponse.loginSuccess(accessToken);
+    }
+}


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #144 

---

## 📝 주요 변경 내용

-  미팅 서비스의 카카오 소셜 로그인 및 회원가입 기능을 구현했습니다.
---

## 🛠️ 작업 상세 내역

 ### **구현 흐름**:
  1. 프론트에서 받은 `code`로 카카오 액세스 토큰 발급
  2. 액세스 토큰으로 카카오 사용자 정보(id) 조회
  3. DB에서 `MeetingProfile` 존재 여부 확인
     - 기존 회원: 즉시 JWT 발급하여 로그인 처리
     - 신규 회원: 임시 회원가입 토큰 발급 (추가 정보 입력 필요)
  4. 신규 회원은 임시 토큰과 함께 추가 정보를 제출하여 회원가입 완료

### 1. Spring Security OAuth2 미사용 이유
  기존 세종라이프 서비스의 포털 로그인 로직과 OAuth2 설정이 충돌하는 문제가 발생했습니다.
  두 인증 방식을 동시에 사용할 경우 Security 설정이 겹치면서 예상치 못한 동작이 발생할 수 있어
  WebClient를 사용한 직접 구현 방식을 선택했습니다.

### 2. 카카오 로그인 플로우
  프론트엔드에서 직접 카카오 인증 서버로 로그인 요청을 보내고
 백엔드는 **인가 코드(code)를 받는 시점부터** 구현했습니다.
  [프론트] → [카카오 서버] → [프론트: code 수신] → [백엔드: code로 토큰 발급]

해당 이미지에 보이는 토큰 요청(인가 코드 포함)부터 구현했습니다.

<img width="808" height="774" alt="image" src="https://github.com/user-attachments/assets/b852870d-7477-4273-8067-8d8169858890" />

### 3. snake_case 필드명 사용
  카카오 API 응답 DTO(`KakaoTokenResponse`, `KakaoUserInfo`)에서 snake_case
  필드명을 사용한 이유는 기존 `KakaoSearchResponse`의 패턴을 따랐습니다.
  자바 컨벤션상으로는 camelCase가 맞지만 팀 코드 일관성을 우선시했습니다.
  (@JsonNaming 어노테이션 대신 필드명을 직접 snake_case로 작성)

 ### 4. Redirect URI 설정 및 application.yml 수정
  `application.yml`에 카카오 OAuth 설정을 추가했습니다.
   Redirect URI는 일단 세종생 메인 페이지(`https://sejonglife.site`)로 설정했습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---