### PR TITLE
fix : 미팅 signup DTO appeal 필드 제거 및 글자 수 제한 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileResponse.java
@@ -12,7 +12,6 @@ public record MeetingProfileResponse(
         Integer birthYear,
         String hobby,
         String dateStyle,
-        String appeal,
         String contact,
         LocalDateTime createdAt
 ) {
@@ -25,7 +24,6 @@ public record MeetingProfileResponse(
                 meetingProfile.getBirthYear(),
                 meetingProfile.getHobby(),
                 meetingProfile.getDateStyle(),
-                meetingProfile.getAppeal(),
                 meetingProfile.getContact(),
                 meetingProfile.getCreatedAt()
         );

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileUpdateRequest.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileUpdateRequest.java
@@ -9,6 +9,5 @@ public record MeetingProfileUpdateRequest(
         Integer birthYear,
         String hobby,
         String dateStyle,
-        String appeal,
         String contact
 ) {}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingSignUpRequest.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingSignUpRequest.java
@@ -2,6 +2,7 @@ package org.example.sejonglifebe.meeting.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 
@@ -16,12 +17,12 @@ public record MeetingSignUpRequest(
         Integer birthYear,
 
         @NotBlank(message = "취미는 필수입니다.")
+        @Size(max = 20, message = "취미는 20자 이내로 입력해주세요.")
         String hobby,
 
         @NotBlank(message = "하고싶은 데이트는 필수입니다.")
+        @Size(max = 30, message = "원하는 데이트 스타일은 30자 이내로 입력해주세요.")
         String dateStyle,
-
-        String appeal,
 
         @NotBlank(message = "연락처는 필수입니다.")
         String contact

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
@@ -45,9 +45,6 @@ public class MeetingProfile {
     @Column(name = "date_style", nullable = false, length = 100)
     private String dateStyle;
 
-    @Column(name = "appeal", columnDefinition = "TEXT")
-    private String appeal;
-
     @Column(name = "contact", nullable = false, length = 100)
     private String contact;
 
@@ -61,7 +58,6 @@ public class MeetingProfile {
             Integer birthYear,
             String hobby,
             String dateStyle,
-            String appeal,
             String contact
     ) {
         this.gender = gender;
@@ -69,7 +65,6 @@ public class MeetingProfile {
         this.birthYear = birthYear;
         this.hobby = hobby;
         this.dateStyle = dateStyle;
-        this.appeal = appeal;
         this.contact = contact;
     }
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -36,7 +36,6 @@ public class MeetingProfileService {
                 request.birthYear(),
                 request.hobby(),
                 request.dateStyle(),
-                request.appeal(),
                 request.contact()
         );
     }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -38,7 +38,6 @@ public class MeetingSignUpService {
                 .birthYear(request.birthYear())
                 .hobby(request.hobby())
                 .dateStyle(request.dateStyle())
-                .appeal(request.appeal())
                 .contact(request.contact())
                 .build();
 

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -60,7 +60,6 @@ class MeetingProfileControllerTest {
                         .birthYear(2000)
                         .hobby("축구")
                         .dateStyle("활동적인 데이트")
-                        .appeal("밝은 성격입니다.")
                         .contact("insta_1")
                         .build()
         );
@@ -73,7 +72,6 @@ class MeetingProfileControllerTest {
                         .birthYear(2001)
                         .hobby("영화")
                         .dateStyle("조용한 데이트")
-                        .appeal("대화가 잘 통합니다.")
                         .contact("insta_2")
                         .build()
         );
@@ -104,7 +102,6 @@ class MeetingProfileControllerTest {
                 1999,
                 "산책",
                 "맛집 데이트",
-                "배려심이 많아요.",
                 "updated_contact"
         );
 
@@ -123,7 +120,6 @@ class MeetingProfileControllerTest {
         assertThat(updated.getBirthYear()).isEqualTo(1999);
         assertThat(updated.getHobby()).isEqualTo("산책");
         assertThat(updated.getDateStyle()).isEqualTo("맛집 데이트");
-        assertThat(updated.getAppeal()).isEqualTo("배려심이 많아요.");
         assertThat(updated.getContact()).isEqualTo("updated_contact");
 
     }
@@ -137,7 +133,6 @@ class MeetingProfileControllerTest {
                 1999,
                 "산책",
                 "맛집 데이트",
-                "배려심이 많아요.",
                 "updated_contact"
         );
 

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -50,7 +50,6 @@ class MeetingProfileServiceTest {
                     .birthYear(2000)
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
-                    .appeal("밝음")
                     .contact("contact1")
                     .build();
 
@@ -61,7 +60,6 @@ class MeetingProfileServiceTest {
                     .birthYear(2001)
                     .hobby("영화")
                     .dateStyle("조용한 데이트")
-                    .appeal("차분함")
                     .contact("contact2")
                     .build();
 
@@ -96,7 +94,6 @@ class MeetingProfileServiceTest {
                     .birthYear(2000)
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
-                    .appeal("밝음")
                     .contact("contact1")
                     .build();
 
@@ -109,7 +106,6 @@ class MeetingProfileServiceTest {
                     1999,
                     "산책",
                     "카페 데이트",
-                    "배려심 많음",
                     "updated_contact"
             );
 
@@ -122,7 +118,6 @@ class MeetingProfileServiceTest {
             assertThat(profile.getBirthYear()).isEqualTo(1999);
             assertThat(profile.getHobby()).isEqualTo("산책");
             assertThat(profile.getDateStyle()).isEqualTo("카페 데이트");
-            assertThat(profile.getAppeal()).isEqualTo("배려심 많음");
             assertThat(profile.getContact()).isEqualTo("updated_contact");
 
             assertThat(profile.getKakaoId()).isEqualTo("kakao-1");
@@ -138,7 +133,6 @@ class MeetingProfileServiceTest {
                     1999,
                     "산책",
                     "카페 데이트",
-                    "배려심 많음",
                     "updated_contact"
             );
 
@@ -164,7 +158,6 @@ class MeetingProfileServiceTest {
                     .birthYear(2000)
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
-                    .appeal("밝음")
                     .contact("contact1")
                     .build();
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #

---

## 📝 주요 변경 내용

- 미팅 회원가입 DTO에서 `appeal` 필드 제거
- `hobby` 최대 20자, `dateStyle` 최대 30자 글자 수 제한 추가

---

## 🛠️ 작업 상세 내역

- `MeetingSignUpRequest`: `appeal` 제거, `@Size` 유효성 검사 추가
- `MeetingProfileUpdateRequest`: `appeal` 제거
- `MeetingProfileResponse`: `appeal` 제거
- `MeetingProfile` 엔티티: `appeal` 필드 및 `update()` 파라미터에서 제거
- `MeetingSignUpService`, `MeetingProfileService`: `appeal` 관련 코드 제거
- 컨트롤러 통합 테스트 및 서비스 단위 테스트 수정

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- `@Size` 제한이 적절한지 확인해 주세요

---