### PR TITLE
feat: 미팅 프로필 목록 조회 시 반대 성별만 조회되도록 변경

### DIFF
--- a/src/main/java/org/example/sejonglifebe/common/config/WebConfig.java
+++ b/src/main/java/org/example/sejonglifebe/common/config/WebConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthInterceptor;
 import org.example.sejonglifebe.auth.AuthUserArgumentResolver;
 import org.example.sejonglifebe.common.logging.LogInterceptor;
+import org.example.sejonglifebe.meeting.auth.MeetingAuthUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -17,6 +18,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthUserArgumentResolver authUserArgumentResolver;
+    private final MeetingAuthUserArgumentResolver meetingAuthUserArgumentResolver;
     private final AuthInterceptor authInterceptor;
     private final ObjectMapper objectMapper;
     private final LogInterceptor logInterceptor;
@@ -24,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authUserArgumentResolver);
+        resolvers.add(meetingAuthUserArgumentResolver);
     }
 
     @Override

--- a/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
@@ -96,6 +96,36 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    // 미팅 최종 토큰 검증 및 카카오 ID 추출
+    public String validateMeetingToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            String type = claims.get("type", String.class);
+            if (!"meeting".equals(type)) {
+                throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+            }
+
+            return claims.getSubject();
+
+        } catch (ExpiredJwtException e) {
+            throw new SejongLifeException(ErrorCode.EXPIRED_TOKEN);
+
+        } catch (MalformedJwtException e) {
+            throw new SejongLifeException(ErrorCode.MALFORMED_TOKEN);
+
+        } catch (SignatureException e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+
+        } catch (Exception e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
     // 미팅 회원가입 토큰 검증 및 카카오 ID 추출
     public String validateMeetingSignUpToken(String token) {
         try {

--- a/src/main/java/org/example/sejonglifebe/meeting/auth/MeetingAuthUserArgumentResolver.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/auth/MeetingAuthUserArgumentResolver.java
@@ -1,0 +1,45 @@
+package org.example.sejonglifebe.meeting.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.common.jwt.JwtTokenExtractor;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingAuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenExtractor jwtTokenExtractor;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getGenericParameterType().equals(MeetingAuthUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null) {
+            return null;
+        }
+
+        String token = jwtTokenExtractor.extractToken(authHeader);
+        if (token.isBlank()) {
+            return null;
+        }
+
+        String kakaoId = jwtTokenProvider.validateMeetingToken(token);
+        return new MeetingAuthUser(kakaoId);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/auth/MeetingAuthUserArgumentResolver.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/auth/MeetingAuthUserArgumentResolver.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.common.jwt.JwtTokenExtractor;
 import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -31,12 +33,12 @@ public class MeetingAuthUserArgumentResolver implements HandlerMethodArgumentRes
 
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (authHeader == null) {
-            return null;
+            throw new SejongLifeException(ErrorCode.INVALID_AUTH_HEADER);
         }
 
         String token = jwtTokenExtractor.extractToken(authHeader);
         if (token.isBlank()) {
-            return null;
+            throw new SejongLifeException(ErrorCode.INVALID_AUTH_HEADER);
         }
 
         String kakaoId = jwtTokenProvider.validateMeetingToken(token);

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -1,6 +1,7 @@
 package org.example.sejonglifebe.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -17,8 +18,8 @@ public class MeetingProfileController {
     private final MeetingProfileService meetingProfileService;
 
     @GetMapping
-    public ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles() {
-        return ResponseEntity.ok(meetingProfileService.getAllMeetingProfiles());
+    public ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {
+        return ResponseEntity.ok(meetingProfileService.getAllMeetingProfiles(meetingAuthUser));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingAuthUser.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingAuthUser.java
@@ -1,0 +1,6 @@
+package org.example.sejonglifebe.meeting.dto;
+
+public record MeetingAuthUser(
+        String kakaoId
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
@@ -1,8 +1,10 @@
 package org.example.sejonglifebe.meeting.repository;
 
+import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, Long> {
@@ -10,4 +12,6 @@ public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, 
     Optional<MeetingProfile> findByKakaoId(String kakaoId);
 
     boolean existsByKakaoId(String kakaoId);
+
+    List<MeetingProfile> findByGender(Gender gender);
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -3,8 +3,10 @@ package org.example.sejonglifebe.meeting.service;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
+import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
 import org.springframework.stereotype.Service;
@@ -19,8 +21,13 @@ public class MeetingProfileService {
 
     private final MeetingProfileRepository meetingProfileRepository;
 
-    public List<MeetingProfileResponse> getAllMeetingProfiles() {
-        return meetingProfileRepository.findAll().stream()
+    public List<MeetingProfileResponse> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {
+        MeetingProfile meetingProfile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        Gender oppositeGender = meetingProfile.getGender() == Gender.MALE ? Gender.FEMALE : Gender.MALE;
+
+        return meetingProfileRepository.findByGender(oppositeGender).stream()
                 .map(MeetingProfileResponse::from)
                 .toList();
     }


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #150 

---

## 📝 주요 변경 내용

-  기존에는 미팅 프로필 목록 조회 시 성별 구분 없이 전체 프로필이 반환되었습니다. 자신의 성별과 반대의 성별만 조회되도록 수정했습니다.

---

## 🛠️ 작업 상세 내역

  - GET /api/meeting/profiles 호출 시 인증된 사용자의 성별을 기준으로 반대 성별 프로필만 필터링하여 반환
  - 카카오 로그인 토큰에서 kakaoId를 추출하는 MeetingAuthUserArgumentResolver 추가
  - 카카오 미팅 토큰 검증 메서드 validateMeetingToken() 추가
  - MeetingProfileRepository에 findByGender() 메서드 추가
  
---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---