### PR TITLE
feat: 프로필 목록 필드 수정 및 연락처 열람용 api 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -1,6 +1,7 @@
 package org.example.sejonglifebe.meeting.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -19,6 +20,11 @@ public class MeetingProfileController {
     @GetMapping
     public ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles() {
         return ResponseEntity.ok(meetingProfileService.getAllMeetingProfiles());
+    }
+
+    @PostMapping("/{profileId}/open")
+    public ResponseEntity<MeetingContactResponse> openContact(@PathVariable Long profileId) {
+        return ResponseEntity.ok(meetingProfileService.openContact(profileId));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
@@ -1,0 +1,4 @@
+package org.example.sejonglifebe.meeting.dto;
+
+public record MeetingContactResponse(String contact) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileResponse.java
@@ -13,7 +13,6 @@ public record MeetingProfileResponse(
         String hobby,
         String dateStyle,
         String appeal,
-        String contact,
         LocalDateTime createdAt
 ) {
     public static MeetingProfileResponse from(MeetingProfile meetingProfile) {
@@ -26,7 +25,6 @@ public record MeetingProfileResponse(
                 meetingProfile.getHobby(),
                 meetingProfile.getDateStyle(),
                 meetingProfile.getAppeal(),
-                meetingProfile.getContact(),
                 meetingProfile.getCreatedAt()
         );
     }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -3,6 +3,7 @@ package org.example.sejonglifebe.meeting.service;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
@@ -39,6 +40,12 @@ public class MeetingProfileService {
                 request.appeal(),
                 request.contact()
         );
+    }
+
+    public MeetingContactResponse openContact(Long id) {
+        MeetingProfile profile = meetingProfileRepository.findById(id)
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
+        return new MeetingContactResponse(profile.getContact());
     }
 
     @Transactional

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -89,7 +90,27 @@ class MeetingProfileControllerTest {
                 .andExpect(jsonPath("$[0].kakaoId").value("kakao-1"))
                 .andExpect(jsonPath("$[0].gender").value("MALE"))
                 .andExpect(jsonPath("$[0].faceType").value("DOG"))
+                .andExpect(jsonPath("$[0].contact").doesNotExist())
                 .andExpect(jsonPath("$[1].kakaoId").value("kakao-2"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("연락처 열람 시 contact가 반환된다")
+    void openContact_success() throws Exception {
+        Long profileId = profile1.getId();
+
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", profileId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contact").value("insta_1"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 반환한다")
+    void openContact_fail_notFound() throws Exception {
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", NON_EXISTENT_ID))
+                .andExpect(status().isNotFound())
                 .andDo(print());
     }
 

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -17,8 +17,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -2,6 +2,7 @@ package org.example.sejonglifebe.meeting;
 
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.FaceType;
@@ -145,6 +146,44 @@ class MeetingProfileServiceTest {
             given(meetingProfileRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> meetingProfileService.updateMeetingProfile(999L, request))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.MEETING_PROFILE_NOT_FOUND.getErrorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("연락처 열람")
+    class OpenContactTest {
+
+        @Test
+        @DisplayName("연락처를 정상적으로 반환한다")
+        void openContact_success() {
+            MeetingProfile profile = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .appeal("밝음")
+                    .contact("insta_contact")
+                    .build();
+
+            ReflectionTestUtils.setField(profile, "id", 1L);
+
+            given(meetingProfileRepository.findById(1L)).willReturn(Optional.of(profile));
+
+            MeetingContactResponse result = meetingProfileService.openContact(1L);
+
+            assertThat(result.contact()).isEqualTo("insta_contact");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 던진다")
+        void openContact_fail_notFound() {
+            given(meetingProfileRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> meetingProfileService.openContact(999L))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.MEETING_PROFILE_NOT_FOUND.getErrorMessage());
         }


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #154 

---

## 📝 주요 변경 내용

- 전체 프로필 목록을 반환 시 contact(연락처) 노출되지 않도록 필드 제거
- 연락처 열람 API 추가
  - POST /api/meeting/profiles/{profileId}/open
  - 존재하지 않는 profileId로 요청 시 404 Not Found 반환

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 연락처 열람 api에 보완하거나 추가해야 할 기능이 있을까요?

---