### PR TITLE
feat: 미팅 연락처 열람권 시스템 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ out/
 
 # Log files
 /logs
+
+# Local notes
+notes.md

--- a/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
+++ b/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
@@ -43,7 +43,8 @@ public enum ErrorCode {
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "유효하지 않은 성별입니다."),
     INVALID_FACE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 얼굴상입니다."),
     INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth State입니다."),
-    MEETING_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미팅 프로필입니다.");
+    MEETING_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미팅 프로필입니다."),
+    INSUFFICIENT_OPEN_COUNT(HttpStatus.FORBIDDEN, "열람권이 부족합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
+++ b/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
@@ -44,7 +44,8 @@ public enum ErrorCode {
     INVALID_FACE_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 얼굴상입니다."),
     INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth State입니다."),
     MEETING_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미팅 프로필입니다."),
-    INSUFFICIENT_OPEN_COUNT(HttpStatus.FORBIDDEN, "열람권이 부족합니다.");
+    INSUFFICIENT_OPEN_COUNT(HttpStatus.FORBIDDEN, "열람권이 부족합니다."),
+    SELF_PROFILE_OPEN_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자신의 프로필은 열람할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -24,8 +24,11 @@ public class MeetingProfileController {
     }
 
     @PostMapping("/{profileId}/open")
-    public ResponseEntity<MeetingContactResponse> openContact(@PathVariable Long profileId) {
-        return ResponseEntity.ok(meetingProfileService.openContact(profileId));
+    public ResponseEntity<MeetingContactResponse> openContact(
+            MeetingAuthUser meetingAuthUser,
+            @PathVariable Long profileId
+    ) {
+        return ResponseEntity.ok(meetingProfileService.openContact(meetingAuthUser, profileId));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
@@ -56,6 +56,9 @@ public class MeetingProfile {
     private LocalDateTime createdAt;
 
     public void decreaseOpenCount() {
+        if (this.availableOpenCount <= 0) {
+            throw new IllegalStateException("열람권이 없습니다.");
+        }
         this.availableOpenCount--;
     }
 

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
@@ -48,9 +48,16 @@ public class MeetingProfile {
     @Column(name = "contact", nullable = false, length = 100)
     private String contact;
 
+    @Column(name = "available_open_count", nullable = false)
+    private int availableOpenCount;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public void decreaseOpenCount() {
+        this.availableOpenCount--;
+    }
 
     public void update(
             Gender gender,

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
@@ -1,13 +1,20 @@
 package org.example.sejonglifebe.meeting.repository;
 
+import jakarta.persistence.LockModeType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM MeetingProfile m WHERE m.kakaoId = :kakaoId")
+    Optional<MeetingProfile> findByKakaoIdWithLock(String kakaoId);
 
     Optional<MeetingProfile> findByKakaoId(String kakaoId);
 

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -50,7 +50,7 @@ public class MeetingProfileService {
 
     @Transactional
     public MeetingContactResponse openContact(MeetingAuthUser meetingAuthUser, Long profileId) {
-        MeetingProfile requester = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+        MeetingProfile requester = meetingProfileRepository.findByKakaoIdWithLock(meetingAuthUser.kakaoId())
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
 
         if (requester.getAvailableOpenCount() <= 0) {

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -53,16 +53,16 @@ public class MeetingProfileService {
         MeetingProfile requester = meetingProfileRepository.findByKakaoIdWithLock(meetingAuthUser.kakaoId())
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
 
+        if (requester.getId().equals(profileId)) {
+            throw new SejongLifeException(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED);
+        }
+
         if (requester.getAvailableOpenCount() <= 0) {
             throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
         }
 
         MeetingProfile target = meetingProfileRepository.findById(profileId)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
-
-        if (requester.getKakaoId().equals(target.getKakaoId())) {
-            throw new SejongLifeException(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED);
-        }
 
         requester.decreaseOpenCount();
 

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -60,6 +60,10 @@ public class MeetingProfileService {
         MeetingProfile target = meetingProfileRepository.findById(profileId)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
+        if (requester.getKakaoId().equals(target.getKakaoId())) {
+            throw new SejongLifeException(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED);
+        }
+
         requester.decreaseOpenCount();
 
         return new MeetingContactResponse(target.getContact());

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -48,10 +48,21 @@ public class MeetingProfileService {
         );
     }
 
-    public MeetingContactResponse openContact(Long id) {
-        MeetingProfile profile = meetingProfileRepository.findById(id)
+    @Transactional
+    public MeetingContactResponse openContact(MeetingAuthUser meetingAuthUser, Long profileId) {
+        MeetingProfile requester = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        if (requester.getAvailableOpenCount() <= 0) {
+            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
+        }
+
+        MeetingProfile target = meetingProfileRepository.findById(profileId)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
-        return new MeetingContactResponse(profile.getContact());
+
+        requester.decreaseOpenCount();
+
+        return new MeetingContactResponse(target.getContact());
     }
 
     @Transactional

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MeetingSignUpService {
 
+    private static final int INITIAL_OPEN_COUNT = 1;
+
     private final MeetingProfileRepository meetingProfileRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -39,7 +41,7 @@ public class MeetingSignUpService {
                 .hobby(request.hobby())
                 .dateStyle(request.dateStyle())
                 .contact(request.contact())
-                .availableOpenCount(1)
+                .availableOpenCount(INITIAL_OPEN_COUNT)
                 .build();
 
         meetingProfileRepository.save(meetingProfile);

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -39,6 +39,7 @@ public class MeetingSignUpService {
                 .hobby(request.hobby())
                 .dateStyle(request.dateStyle())
                 .contact(request.contact())
+                .availableOpenCount(1)
                 .build();
 
         meetingProfileRepository.save(meetingProfile);

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -137,6 +137,17 @@ class MeetingProfileControllerTest {
     }
 
     @Test
+    @DisplayName("자신의 프로필 열람 시 400을 반환한다")
+    void openContact_fail_selfProfile() throws Exception {
+        String token = jwtTokenProvider.createMeetingToken("kakao-1");
+
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", profile1.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
     @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 반환한다")
     void openContact_fail_notFound() throws Exception {
         String token = jwtTokenProvider.createMeetingToken("kakao-1");

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -65,6 +65,7 @@ class MeetingProfileControllerTest {
                         .hobby("축구")
                         .dateStyle("활동적인 데이트")
                         .contact("insta_1")
+                        .availableOpenCount(1)
                         .build()
         );
 
@@ -77,6 +78,7 @@ class MeetingProfileControllerTest {
                         .hobby("영화")
                         .dateStyle("조용한 데이트")
                         .contact("insta_2")
+                        .availableOpenCount(1)
                         .build()
         );
     }
@@ -99,20 +101,48 @@ class MeetingProfileControllerTest {
     }
 
     @Test
-    @DisplayName("연락처 열람 시 contact가 반환된다")
+    @DisplayName("열람권이 있을 때 연락처가 반환되고 열람권이 차감된다")
     void openContact_success() throws Exception {
-        Long profileId = profile1.getId();
+        String token = jwtTokenProvider.createMeetingToken("kakao-1");
+        Long targetProfileId = profile2.getId();
 
-        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", profileId))
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", targetProfileId)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.contact").value("insta_1"))
+                .andExpect(jsonPath("$.contact").value("insta_2"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("열람권이 없을 때 403을 반환한다")
+    void openContact_fail_insufficientOpenCount() throws Exception {
+        meetingProfileRepository.save(
+                MeetingProfile.builder()
+                        .kakaoId("kakao-3")
+                        .gender(Gender.MALE)
+                        .faceType(FaceType.BEAR)
+                        .birthYear(1999)
+                        .hobby("독서")
+                        .dateStyle("집에서 데이트")
+                        .contact("insta_3")
+                        .availableOpenCount(0)
+                        .build()
+        );
+        String token = jwtTokenProvider.createMeetingToken("kakao-3");
+
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", profile2.getId())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isForbidden())
                 .andDo(print());
     }
 
     @Test
     @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 반환한다")
     void openContact_fail_notFound() throws Exception {
-        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", NON_EXISTENT_ID))
+        String token = jwtTokenProvider.createMeetingToken("kakao-1");
+
+        mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", NON_EXISTENT_ID)
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isNotFound())
                 .andDo(print());
     }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -215,6 +215,32 @@ class MeetingProfileServiceTest {
         }
 
         @Test
+        @DisplayName("자신의 프로필 열람 시 예외를 던진다")
+        void openContact_fail_selfProfile() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .availableOpenCount(1)
+                    .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(1L)).willReturn(Optional.of(requester));
+
+            assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 1L))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED.getErrorMessage());
+        }
+
+        @Test
         @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 던진다")
         void openContact_fail_notFound() {
             MeetingProfile requester = MeetingProfile.builder()

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -154,33 +154,86 @@ class MeetingProfileServiceTest {
     class OpenContactTest {
 
         @Test
-        @DisplayName("연락처를 정상적으로 반환한다")
+        @DisplayName("열람권이 있을 때 연락처를 정상적으로 반환하고 열람권을 차감한다")
         void openContact_success() {
-            MeetingProfile profile = MeetingProfile.builder()
+            MeetingProfile requester = MeetingProfile.builder()
                     .kakaoId("kakao-1")
                     .gender(Gender.MALE)
                     .faceType(FaceType.DOG)
                     .birthYear(2000)
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
-                    .contact("insta_contact")
+                    .contact("requester_contact")
+                    .availableOpenCount(1)
                     .build();
 
-            ReflectionTestUtils.setField(profile, "id", 1L);
+            MeetingProfile target = MeetingProfile.builder()
+                    .kakaoId("kakao-2")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(2001)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("insta_contact")
+                    .availableOpenCount(1)
+                    .build();
 
-            given(meetingProfileRepository.findById(1L)).willReturn(Optional.of(profile));
+            ReflectionTestUtils.setField(target, "id", 2L);
 
-            MeetingContactResponse result = meetingProfileService.openContact(1L);
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+
+            MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
 
             assertThat(result.contact()).isEqualTo("insta_contact");
+            assertThat(requester.getAvailableOpenCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("열람권이 없을 때 예외를 던진다")
+        void openContact_fail_insufficientOpenCount() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .availableOpenCount(0)
+                    .build();
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+
+            assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 2L))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.INSUFFICIENT_OPEN_COUNT.getErrorMessage());
         }
 
         @Test
         @DisplayName("존재하지 않는 프로필 연락처 열람 시 예외를 던진다")
         void openContact_fail_notFound() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .availableOpenCount(1)
+                    .build();
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(999L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> meetingProfileService.openContact(999L))
+            assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 999L))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.MEETING_PROFILE_NOT_FOUND.getErrorMessage());
         }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -182,7 +182,7 @@ class MeetingProfileServiceTest {
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
-            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
 
             MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
@@ -207,7 +207,7 @@ class MeetingProfileServiceTest {
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
-            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 2L))
                     .isInstanceOf(SejongLifeException.class)
@@ -232,7 +232,7 @@ class MeetingProfileServiceTest {
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
-            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(1L)).willReturn(Optional.of(requester));
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 1L))
@@ -256,7 +256,7 @@ class MeetingProfileServiceTest {
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
-            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 999L))


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #160

---

## 📝 주요 변경 내용

- `MeetingProfile`에 `availableOpenCount` 필드 추가 및 회원가입 시 열람권 1개 초기화
- 연락처 열람 API에 열람권 검증/차감 로직 추가
  - `POST /api/meeting/profiles/{profileId}/open`
  - 열람권이 없는 경우 403 Forbidden 반환

---

## 🛠️ 작업 상세 내역

- `MeetingProfile`: `availableOpenCount` 필드 및 `decreaseOpenCount()` 메서드 추가
- `MeetingProfileService`: `openContact()` 호출 시 요청자의 열람권 확인 후 차감, 대상 연락처 반환
- `MeetingSignUpService`: 회원가입 시 `availableOpenCount = 1` 지급
- `ErrorCode`: `INSUFFICIENT_OPEN_COUNT(403, "열람권이 부족합니다.")` 추가
- 서비스/컨트롤러 테스트 추가 (성공, 열람권 부족, 대상 없음 케이스)

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 열람권 충전 API가 별도로 필요할까요? (현재는 가입 시 1개 고정)
- 자기 자신 프로필을 열람하는 경우에 대한 방어 로직이 필요할까요?

---

## ⚠️ 머지 전 DB 작업 필요

```sql
ALTER TABLE meeting_profiles
    ADD COLUMN available_open_count INT NOT NULL;
```

> 기존 가입된 유저에게도 열람권 1개 부여. 필요 시 DEFAULT 값 조정