### PR TITLE
fix: MeetingProfileServiceTest 연락처 열람 테스트 수정

### DIFF
--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -178,6 +178,7 @@ class MeetingProfileServiceTest {
                     .availableOpenCount(1)
                     .build();
 
+            ReflectionTestUtils.setField(requester, "id", 1L);
             ReflectionTestUtils.setField(target, "id", 2L);
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
@@ -204,6 +205,8 @@ class MeetingProfileServiceTest {
                     .contact("requester_contact")
                     .availableOpenCount(0)
                     .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
@@ -233,7 +236,6 @@ class MeetingProfileServiceTest {
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
-            given(meetingProfileRepository.findById(1L)).willReturn(Optional.of(requester));
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 1L))
                     .isInstanceOf(SejongLifeException.class)
@@ -253,6 +255,8 @@ class MeetingProfileServiceTest {
                     .contact("requester_contact")
                     .availableOpenCount(1)
                     .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
 
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #162 

---

## 📝 주요 변경 내용

- 서비스 코드의 자기 자신 체크 로직이 kakaoId 비교 → id 비교로 변경된 것을 테스트에 반영

---

## 🛠️ 작업 상세 내역

-
-

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---