### PR TITLE
feat: 마지막 열람권 사용 후 1시간 마다 갱신되는 로직 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -3,6 +3,7 @@ package org.example.sejonglifebe.meeting.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -14,13 +15,18 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/meeting/profiles")
-public class MeetingProfileController {
+public class MeetingProfileController implements MeetingProfileControllerSwagger {
 
     private final MeetingProfileService meetingProfileService;
 
     @GetMapping
     public ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {
         return ResponseEntity.ok(meetingProfileService.getAllMeetingProfiles(meetingAuthUser));
+    }
+
+    @GetMapping("/open-count")
+    public ResponseEntity<MeetingOpenCountResponse> getOpenCount(MeetingAuthUser meetingAuthUser) {
+        return ResponseEntity.ok(meetingProfileService.getOpenCount(meetingAuthUser));
     }
 
     @PostMapping("/{profileId}/open")

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
@@ -1,0 +1,60 @@
+package org.example.sejonglifebe.meeting.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Meeting Profile", description = "미팅 프로필 관리")
+public interface MeetingProfileControllerSwagger {
+
+    @Operation(
+            summary = "미팅 프로필 전체 조회",
+            description = "로그인한 사용자의 반대 성별 미팅 프로필 목록을 조회합니다."
+    )
+    ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser);
+
+    @Operation(
+            summary = "열람권 현황 조회",
+            description = "보너스 열람권 수량과 쿨다운 남은 시간(초)을 반환합니다. 쿨다운이 끝났으면 사용 가능 열람권을 1로 반환합니다."
+    )
+    ResponseEntity<MeetingOpenCountResponse> getOpenCount(MeetingAuthUser meetingAuthUser);
+
+    @Operation(
+            summary = "연락처 열람",
+            description = "열람권을 사용해 상대방의 연락처를 조회합니다. 보너스 열람권을 먼저 차감하며, 보너스가 없고 쿨다운이 끝났으면 쿨다운을 시작하고 연락처를 반환합니다."
+    )
+    ResponseEntity<MeetingContactResponse> openContact(
+            MeetingAuthUser meetingAuthUser,
+            @Parameter(description = "열람할 프로필 ID", required = true)
+            @PathVariable Long profileId
+    );
+
+    @Operation(
+            summary = "미팅 프로필 수정",
+            description = "미팅 프로필 정보를 수정합니다."
+    )
+    ResponseEntity<Void> updateMeetingProfile(
+            @Parameter(description = "프로필 ID", required = true)
+            @PathVariable Long id,
+            @RequestBody MeetingProfileUpdateRequest request
+    );
+
+    @Operation(
+            summary = "미팅 프로필 삭제",
+            description = "미팅 프로필을 삭제합니다."
+    )
+    ResponseEntity<Void> deleteMeetingProfile(
+            @Parameter(description = "프로필 ID", required = true)
+            @PathVariable Long id
+    );
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingOpenCountResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingOpenCountResponse.java
@@ -1,0 +1,8 @@
+package org.example.sejonglifebe.meeting.dto;
+
+public record MeetingOpenCountResponse(
+        int availableOpenCount,
+        int bonusOpenCount,
+        long cooldownRemainingSeconds
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingProfile.java
@@ -6,6 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -48,18 +51,26 @@ public class MeetingProfile {
     @Column(name = "contact", nullable = false, length = 100)
     private String contact;
 
-    @Column(name = "available_open_count", nullable = false)
-    private int availableOpenCount;
+    @Column(name = "bonus_open_count", nullable = false)
+    private int bonusOpenCount;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public void decreaseOpenCount() {
-        if (this.availableOpenCount <= 0) {
-            throw new IllegalStateException("열람권이 없습니다.");
+    public void increaseBonusOpenCount() {
+        this.bonusOpenCount++;
+    }
+
+    public boolean hasBonusOpenCount() {
+        return this.bonusOpenCount > 0;
+    }
+
+    public void decreaseBonusOpenCount() {
+        if (this.bonusOpenCount <= 0) {
+            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
         }
-        this.availableOpenCount--;
+        this.bonusOpenCount--;
     }
 
     public void update(

--- a/src/main/java/org/example/sejonglifebe/meeting/service/CooldownStartEvent.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/CooldownStartEvent.java
@@ -1,0 +1,4 @@
+package org.example.sejonglifebe.meeting.service;
+
+public record CooldownStartEvent(String kakaoId) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingOpenCountEventListener.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingOpenCountEventListener.java
@@ -1,0 +1,18 @@
+package org.example.sejonglifebe.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingOpenCountEventListener {
+
+    private final MeetingOpenCountService meetingOpenCountService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCooldownStart(CooldownStartEvent event) {
+        meetingOpenCountService.startCooldown(event.kakaoId());
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingOpenCountService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingOpenCountService.java
@@ -1,0 +1,35 @@
+package org.example.sejonglifebe.meeting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingOpenCountService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final Duration RECHARGE_COOLDOWN = Duration.ofHours(1);
+    private static final String KEY_PREFIX = "meeting:recharge:";
+
+    public boolean isRechargeable(String kakaoId) {
+        return !Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + kakaoId));
+    }
+
+    public long getRemainingCooldownSeconds(String kakaoId) {
+        Long ttl = redisTemplate.getExpire(KEY_PREFIX + kakaoId, TimeUnit.SECONDS);
+        return (ttl != null && ttl > 0) ? ttl : 0L;
+    }
+
+    public void startCooldown(String kakaoId) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + kakaoId, "1", RECHARGE_COOLDOWN);
+    }
+
+    public void clearCooldown(String kakaoId) {
+        redisTemplate.delete(KEY_PREFIX + kakaoId);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -11,6 +11,7 @@ import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class MeetingProfileService {
 
     private final MeetingProfileRepository meetingProfileRepository;
     private final MeetingOpenCountService meetingOpenCountService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public MeetingOpenCountResponse getOpenCount(MeetingAuthUser meetingAuthUser) {
         MeetingProfile profile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
@@ -75,7 +77,7 @@ public class MeetingProfileService {
         if (requester.hasBonusOpenCount()) {
             requester.decreaseBonusOpenCount();
         } else if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
-            meetingOpenCountService.startCooldown(meetingAuthUser.kakaoId());
+            eventPublisher.publishEvent(new CooldownStartEvent(meetingAuthUser.kakaoId()));
         } else {
             throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
         }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -71,9 +71,6 @@ public class MeetingProfileService {
             throw new SejongLifeException(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED);
         }
 
-        MeetingProfile target = meetingProfileRepository.findById(profileId)
-                .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
-
         if (requester.hasBonusOpenCount()) {
             requester.decreaseBonusOpenCount();
         } else if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
@@ -81,6 +78,9 @@ public class MeetingProfileService {
         } else {
             throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
         }
+
+        MeetingProfile target = meetingProfileRepository.findById(profileId)
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
         return new MeetingContactResponse(target.getContact());
     }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -5,6 +5,7 @@ import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.Gender;
@@ -21,6 +22,17 @@ import java.util.List;
 public class MeetingProfileService {
 
     private final MeetingProfileRepository meetingProfileRepository;
+    private final MeetingOpenCountService meetingOpenCountService;
+
+    public MeetingOpenCountResponse getOpenCount(MeetingAuthUser meetingAuthUser) {
+        MeetingProfile profile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        long remaining = meetingOpenCountService.getRemainingCooldownSeconds(meetingAuthUser.kakaoId());
+        int availableCount = remaining == 0 ? 1 : 0;
+
+        return new MeetingOpenCountResponse(availableCount, profile.getBonusOpenCount(), remaining);
+    }
 
     public List<MeetingProfileResponse> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {
         MeetingProfile meetingProfile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
@@ -57,14 +69,16 @@ public class MeetingProfileService {
             throw new SejongLifeException(ErrorCode.SELF_PROFILE_OPEN_NOT_ALLOWED);
         }
 
-        if (requester.getAvailableOpenCount() <= 0) {
-            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
-        }
-
         MeetingProfile target = meetingProfileRepository.findById(profileId)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
-        requester.decreaseOpenCount();
+        if (requester.hasBonusOpenCount()) {
+            requester.decreaseBonusOpenCount();
+        } else if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
+            meetingOpenCountService.startCooldown(meetingAuthUser.kakaoId());
+        } else {
+            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
+        }
 
         return new MeetingContactResponse(target.getContact());
     }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -17,8 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MeetingSignUpService {
 
-    private static final int INITIAL_OPEN_COUNT = 1;
-
     private final MeetingProfileRepository meetingProfileRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -41,7 +39,6 @@ public class MeetingSignUpService {
                 .hobby(request.hobby())
                 .dateStyle(request.dateStyle())
                 .contact(request.contact())
-                .availableOpenCount(INITIAL_OPEN_COUNT)
                 .build();
 
         meetingProfileRepository.save(meetingProfile);

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingOpenCountEventListenerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingOpenCountEventListenerTest.java
@@ -1,0 +1,84 @@
+package org.example.sejonglifebe.meeting;
+
+import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.example.sejonglifebe.meeting.entity.FaceType;
+import org.example.sejonglifebe.meeting.entity.Gender;
+import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
+import org.example.sejonglifebe.meeting.service.MeetingProfileService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MeetingOpenCountEventListenerTest {
+
+    @Autowired
+    private MeetingProfileService meetingProfileService;
+
+    @Autowired
+    private MeetingOpenCountService meetingOpenCountService;
+
+    @Autowired
+    private MeetingProfileRepository meetingProfileRepository;
+
+    private static final String REQUESTER_KAKAO_ID = "kakao-event-test-1";
+    private static final String TARGET_KAKAO_ID = "kakao-event-test-2";
+
+    @BeforeEach
+    void setUp() {
+        MeetingProfile requester = MeetingProfile.builder()
+                .kakaoId(REQUESTER_KAKAO_ID)
+                .gender(Gender.MALE)
+                .faceType(FaceType.DOG)
+                .birthYear(2000)
+                .hobby("축구")
+                .dateStyle("활동적인 데이트")
+                .contact("requester_contact")
+                .bonusOpenCount(0)
+                .build();
+
+        MeetingProfile target = MeetingProfile.builder()
+                .kakaoId(TARGET_KAKAO_ID)
+                .gender(Gender.FEMALE)
+                .faceType(FaceType.CAT)
+                .birthYear(2001)
+                .hobby("영화")
+                .dateStyle("조용한 데이트")
+                .contact("target_contact")
+                .bonusOpenCount(0)
+                .build();
+
+        meetingProfileRepository.save(requester);
+        meetingProfileRepository.save(target);
+    }
+
+    @AfterEach
+    void tearDown() {
+        meetingProfileRepository.findByKakaoId(REQUESTER_KAKAO_ID).ifPresent(meetingProfileRepository::delete);
+        meetingProfileRepository.findByKakaoId(TARGET_KAKAO_ID).ifPresent(meetingProfileRepository::delete);
+        meetingOpenCountService.clearCooldown(REQUESTER_KAKAO_ID);
+    }
+
+    @Test
+    @DisplayName("openContact 트랜잭션 커밋 후 AFTER_COMMIT으로 Redis 쿨다운이 설정된다")
+    void afterCommit_cooldown_is_set() {
+        MeetingAuthUser meetingAuthUser = new MeetingAuthUser(REQUESTER_KAKAO_ID);
+        MeetingProfile target = meetingProfileRepository.findByKakaoId(TARGET_KAKAO_ID).orElseThrow();
+
+        assertThat(meetingOpenCountService.isRechargeable(REQUESTER_KAKAO_ID)).isTrue();
+
+        meetingProfileService.openContact(meetingAuthUser, target.getId());
+
+        assertThat(meetingOpenCountService.isRechargeable(REQUESTER_KAKAO_ID)).isFalse();
+        assertThat(meetingOpenCountService.getRemainingCooldownSeconds(REQUESTER_KAKAO_ID)).isGreaterThan(0);
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileControllerTest.java
@@ -8,6 +8,7 @@ import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,11 +50,17 @@ class MeetingProfileControllerTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    @Autowired
+    private MeetingOpenCountService meetingOpenCountService;
+
     private MeetingProfile profile1;
     private MeetingProfile profile2;
 
     @BeforeEach
     void setUp() {
+        meetingOpenCountService.clearCooldown("kakao-1");
+        meetingOpenCountService.clearCooldown("kakao-2");
+        meetingOpenCountService.clearCooldown("kakao-3");
         meetingProfileRepository.deleteAll();
 
         profile1 = meetingProfileRepository.save(
@@ -65,7 +72,6 @@ class MeetingProfileControllerTest {
                         .hobby("축구")
                         .dateStyle("활동적인 데이트")
                         .contact("insta_1")
-                        .availableOpenCount(1)
                         .build()
         );
 
@@ -78,7 +84,6 @@ class MeetingProfileControllerTest {
                         .hobby("영화")
                         .dateStyle("조용한 데이트")
                         .contact("insta_2")
-                        .availableOpenCount(1)
                         .build()
         );
     }
@@ -125,9 +130,10 @@ class MeetingProfileControllerTest {
                         .hobby("독서")
                         .dateStyle("집에서 데이트")
                         .contact("insta_3")
-                        .availableOpenCount(0)
                         .build()
         );
+        meetingOpenCountService.startCooldown("kakao-3");
+
         String token = jwtTokenProvider.createMeetingToken("kakao-3");
 
         mockMvc.perform(post("/api/meeting/profiles/{profileId}/open", profile2.getId())

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -11,15 +11,18 @@ import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.service.CooldownStartEvent;
 import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -39,6 +42,9 @@ class MeetingProfileServiceTest {
 
     @Mock
     private MeetingOpenCountService meetingOpenCountService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private MeetingProfileService meetingProfileService;
@@ -195,7 +201,10 @@ class MeetingProfileServiceTest {
             MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
 
             assertThat(result.contact()).isEqualTo("insta_contact");
-            verify(meetingOpenCountService).startCooldown("kakao-1");
+
+            ArgumentCaptor<CooldownStartEvent> captor = ArgumentCaptor.forClass(CooldownStartEvent.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            assertThat(captor.getValue().kakaoId()).isEqualTo("kakao-1");
         }
 
         @Test

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -264,10 +264,6 @@ class MeetingProfileServiceTest {
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
-            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(MeetingProfile.builder()
-                    .kakaoId("kakao-2").gender(Gender.FEMALE).faceType(FaceType.CAT)
-                    .birthYear(2001).hobby("영화").dateStyle("조용한 데이트").contact("insta_contact")
-                    .bonusOpenCount(0).build()));
             given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(false);
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 2L))
@@ -319,6 +315,7 @@ class MeetingProfileServiceTest {
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(true);
             given(meetingProfileRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 999L))

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -4,12 +4,14 @@ import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
+import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +36,9 @@ class MeetingProfileServiceTest {
 
     @Mock
     private MeetingProfileRepository meetingProfileRepository;
+
+    @Mock
+    private MeetingOpenCountService meetingOpenCountService;
 
     @InjectMocks
     private MeetingProfileService meetingProfileService;
@@ -154,7 +159,7 @@ class MeetingProfileServiceTest {
     class OpenContactTest {
 
         @Test
-        @DisplayName("열람권이 있을 때 연락처를 정상적으로 반환하고 열람권을 차감한다")
+        @DisplayName("쿨다운이 끝났을 때 연락처를 반환하고 쿨다운을 시작한다")
         void openContact_success() {
             MeetingProfile requester = MeetingProfile.builder()
                     .kakaoId("kakao-1")
@@ -164,7 +169,7 @@ class MeetingProfileServiceTest {
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
                     .contact("requester_contact")
-                    .availableOpenCount(1)
+                    .bonusOpenCount(0)
                     .build();
 
             MeetingProfile target = MeetingProfile.builder()
@@ -175,7 +180,47 @@ class MeetingProfileServiceTest {
                     .hobby("영화")
                     .dateStyle("조용한 데이트")
                     .contact("insta_contact")
-                    .availableOpenCount(1)
+                    .bonusOpenCount(0)
+                    .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
+            ReflectionTestUtils.setField(target, "id", 2L);
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+            given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(true);
+
+            MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
+
+            assertThat(result.contact()).isEqualTo("insta_contact");
+            verify(meetingOpenCountService).startCooldown("kakao-1");
+        }
+
+        @Test
+        @DisplayName("보너스 열람권이 있을 때 보너스 열람권을 먼저 차감한다")
+        void openContact_success_bonusFirst() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .bonusOpenCount(1)
+                    .build();
+
+            MeetingProfile target = MeetingProfile.builder()
+                    .kakaoId("kakao-2")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(2001)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("insta_contact")
+                    .bonusOpenCount(0)
                     .build();
 
             ReflectionTestUtils.setField(requester, "id", 1L);
@@ -186,14 +231,13 @@ class MeetingProfileServiceTest {
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
 
-            MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
+            meetingProfileService.openContact(meetingAuthUser, 2L);
 
-            assertThat(result.contact()).isEqualTo("insta_contact");
-            assertThat(requester.getAvailableOpenCount()).isEqualTo(0);
+            assertThat(requester.getBonusOpenCount()).isEqualTo(0);
         }
 
         @Test
-        @DisplayName("열람권이 없을 때 예외를 던진다")
+        @DisplayName("열람권이 없고 쿨다운 중이면 예외를 던진다")
         void openContact_fail_insufficientOpenCount() {
             MeetingProfile requester = MeetingProfile.builder()
                     .kakaoId("kakao-1")
@@ -203,7 +247,7 @@ class MeetingProfileServiceTest {
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
                     .contact("requester_contact")
-                    .availableOpenCount(0)
+                    .bonusOpenCount(0)
                     .build();
 
             ReflectionTestUtils.setField(requester, "id", 1L);
@@ -211,6 +255,11 @@ class MeetingProfileServiceTest {
             MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(MeetingProfile.builder()
+                    .kakaoId("kakao-2").gender(Gender.FEMALE).faceType(FaceType.CAT)
+                    .birthYear(2001).hobby("영화").dateStyle("조용한 데이트").contact("insta_contact")
+                    .bonusOpenCount(0).build()));
+            given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(false);
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 2L))
                     .isInstanceOf(SejongLifeException.class)
@@ -228,7 +277,7 @@ class MeetingProfileServiceTest {
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
                     .contact("requester_contact")
-                    .availableOpenCount(1)
+                    .bonusOpenCount(0)
                     .build();
 
             ReflectionTestUtils.setField(requester, "id", 1L);
@@ -253,7 +302,7 @@ class MeetingProfileServiceTest {
                     .hobby("축구")
                     .dateStyle("활동적인 데이트")
                     .contact("requester_contact")
-                    .availableOpenCount(1)
+                    .bonusOpenCount(0)
                     .build();
 
             ReflectionTestUtils.setField(requester, "id", 1L);
@@ -266,6 +315,75 @@ class MeetingProfileServiceTest {
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 999L))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.MEETING_PROFILE_NOT_FOUND.getErrorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("열람권 조회")
+    class GetOpenCountTest {
+
+        @Test
+        @DisplayName("쿨다운 중일 때 열람권 0과 남은 시간을 반환한다")
+        void getOpenCount_duringCooldown() {
+            MeetingProfile profile = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("contact1")
+                    .bonusOpenCount(1)
+                    .build();
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(profile));
+            given(meetingOpenCountService.getRemainingCooldownSeconds("kakao-1")).willReturn(2400L);
+
+            MeetingOpenCountResponse result = meetingProfileService.getOpenCount(meetingAuthUser);
+
+            assertThat(result.availableOpenCount()).isEqualTo(0);
+            assertThat(result.bonusOpenCount()).isEqualTo(1);
+            assertThat(result.cooldownRemainingSeconds()).isEqualTo(2400L);
+        }
+
+        @Test
+        @DisplayName("쿨다운이 끝났을 때 열람권 1과 남은 시간 0을 반환한다")
+        void getOpenCount_cooldownFinished() {
+            MeetingProfile profile = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("contact1")
+                    .bonusOpenCount(0)
+                    .build();
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(profile));
+            given(meetingOpenCountService.getRemainingCooldownSeconds("kakao-1")).willReturn(0L);
+
+            MeetingOpenCountResponse result = meetingProfileService.getOpenCount(meetingAuthUser);
+
+            assertThat(result.availableOpenCount()).isEqualTo(1);
+            assertThat(result.bonusOpenCount()).isEqualTo(0);
+            assertThat(result.cooldownRemainingSeconds()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저 열람권 조회 시 예외를 던진다")
+        void getOpenCount_fail_userNotFound() {
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-999");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-999")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> meetingProfileService.getOpenCount(meetingAuthUser))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.USER_NOT_FOUND.getErrorMessage());
         }
     }
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #164

---

## 📝 주요 변경 내용

-  미팅 연락처 열람권 1시간 쿨다운 시스템 구현 (Redis TTL 기반)
- 보너스 열람권(bonusOpenCount) 필드 추가 — 친구 초대로 지급

---

## 🛠️ 작업 상세 내역

 ## 일반 열람권을 DB 필드 없이 Redis로만 관리한 이유

초기 설계에서는 availableOpenCount를 DB에 저장하는 방식을 고려했습니다. 
그러나 열람 시 DB 값을 0으로 만들고 1시간 후 다시 1로 올려야 하는데 그 충전 시점을 처리하려면 스케줄러나 배치가 필요해 복잡해집니다.

Redis TTL을 사용하면 키 만료 자체가 "충전"이기 때문에 별도 처리가 필요 없습니다. DB 필드와 Redis 상태를 동기화할 필요도 없어집니다.
또, 현재 중복 방지를 위한 별도의 테이블에 데이터를 관리하기 때문에 추적 관리에도 문제가 없을 것 같습니다.

  그래서 일반 열람권은 Redis 키 유무로만 상태를 표현하는 방식으로 결정했습니다.
  - Redis에 키가 없음 → 열람 가능 (열람권 1개)
  - Redis에 키가 있음 → 쿨다운 중 (열람 불가)

열람 시 Redis에 1시간 TTL 키를 생성하고 TTL이 만료되면 자동으로 다시 열람 가능 상태가 됩니다. DB 필드 없이 Redis 하나로 상태를 일관되게 관리하도록 변경했습니다.

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 

---