### PR TITLE
feat: 연락처 중복 열람 시 열람권 차감 방지

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
@@ -1,4 +1,6 @@
 package org.example.sejonglifebe.meeting.dto;
 
-public record MeetingContactResponse(String contact) {
+public record MeetingContactResponse(
+        String contact,
+        boolean alreadyViewed) {
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingContactResponse.java
@@ -1,6 +1,11 @@
 package org.example.sejonglifebe.meeting.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "연락처 열람 응답")
 public record MeetingContactResponse(
+        @Schema(description = "상대방 연락처")
         String contact,
+        @Schema(description = "이미 열람한 프로필 여부. true이면 열람권 차감 없이 반환된 것")
         boolean alreadyViewed) {
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/ContactViewHistory.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/ContactViewHistory.java
@@ -1,0 +1,42 @@
+package org.example.sejonglifebe.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "contact_view_histories",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"viewer_profile_id", "target_profile_id"}))
+public class ContactViewHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "viewer_profile_id", nullable = false)
+    private MeetingProfile viewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_profile_id", nullable = false)
+    private MeetingProfile target;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime viewedAt;
+
+    @Builder
+    public ContactViewHistory(MeetingProfile viewer, MeetingProfile target) {
+        this.viewer = viewer;
+        this.target = target;
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/ContactViewHistoryRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/ContactViewHistoryRepository.java
@@ -1,0 +1,9 @@
+package org.example.sejonglifebe.meeting.repository;
+
+import org.example.sejonglifebe.meeting.entity.ContactViewHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContactViewHistoryRepository extends JpaRepository<ContactViewHistory, Long> {
+
+    boolean existsByViewerIdAndTargetId(Long viewerId, Long targetId);
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/ContactViewHistoryRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/ContactViewHistoryRepository.java
@@ -6,4 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ContactViewHistoryRepository extends JpaRepository<ContactViewHistory, Long> {
 
     boolean existsByViewerIdAndTargetId(Long viewerId, Long targetId);
+
+    void deleteByViewerId(Long viewerId);
+
+    void deleteByTargetId(Long targetId);
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -8,8 +8,10 @@ import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
+import org.example.sejonglifebe.meeting.entity.ContactViewHistory;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.ContactViewHistoryRepository;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,7 @@ import java.util.List;
 public class MeetingProfileService {
 
     private final MeetingProfileRepository meetingProfileRepository;
+    private final ContactViewHistoryRepository contactViewHistoryRepository;
     private final MeetingOpenCountService meetingOpenCountService;
 
     public MeetingOpenCountResponse getOpenCount(MeetingAuthUser meetingAuthUser) {
@@ -72,15 +75,18 @@ public class MeetingProfileService {
         MeetingProfile target = meetingProfileRepository.findById(profileId)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
-        if (requester.hasBonusOpenCount()) {
-            requester.decreaseBonusOpenCount();
-        } else if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
-            meetingOpenCountService.startCooldown(meetingAuthUser.kakaoId());
-        } else {
-            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
+        boolean alreadyViewed = contactViewHistoryRepository
+                .existsByViewerIdAndTargetId(requester.getId(), profileId);
+
+        if (!alreadyViewed) {
+            useOpenCount(requester, meetingAuthUser.kakaoId());
+            contactViewHistoryRepository.save(ContactViewHistory.builder()
+                    .viewer(requester)
+                    .target(target)
+                    .build());
         }
 
-        return new MeetingContactResponse(target.getContact());
+        return new MeetingContactResponse(target.getContact(), alreadyViewed);
     }
 
     @Transactional
@@ -89,5 +95,15 @@ public class MeetingProfileService {
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
         meetingProfileRepository.delete(profile);
+    }
+
+    private void useOpenCount(MeetingProfile requester, String kakaoId) {
+        if (requester.hasBonusOpenCount()) {
+            requester.decreaseBonusOpenCount();
+        } else if (meetingOpenCountService.isRechargeable(kakaoId)) {
+            meetingOpenCountService.startCooldown(kakaoId);
+        } else {
+            throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
+        }
     }
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -102,6 +102,8 @@ public class MeetingProfileService {
         MeetingProfile profile = meetingProfileRepository.findById(id)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
+        contactViewHistoryRepository.deleteByViewerId(id);
+        contactViewHistoryRepository.deleteByTargetId(id);
         meetingProfileRepository.delete(profile);
     }
 }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -10,6 +10,7 @@ import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.ContactViewHistoryRepository;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
 import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -36,6 +37,9 @@ class MeetingProfileServiceTest {
 
     @Mock
     private MeetingProfileRepository meetingProfileRepository;
+
+    @Mock
+    private ContactViewHistoryRepository contactViewHistoryRepository;
 
     @Mock
     private MeetingOpenCountService meetingOpenCountService;
@@ -190,11 +194,13 @@ class MeetingProfileServiceTest {
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+            given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(false);
             given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(true);
 
             MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
 
             assertThat(result.contact()).isEqualTo("insta_contact");
+            assertThat(result.alreadyViewed()).isFalse();
             verify(meetingOpenCountService).startCooldown("kakao-1");
         }
 
@@ -230,6 +236,7 @@ class MeetingProfileServiceTest {
 
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+            given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(false);
 
             meetingProfileService.openContact(meetingAuthUser, 2L);
 
@@ -259,11 +266,53 @@ class MeetingProfileServiceTest {
                     .kakaoId("kakao-2").gender(Gender.FEMALE).faceType(FaceType.CAT)
                     .birthYear(2001).hobby("영화").dateStyle("조용한 데이트").contact("insta_contact")
                     .bonusOpenCount(0).build()));
+            given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(false);
             given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(false);
 
             assertThatThrownBy(() -> meetingProfileService.openContact(meetingAuthUser, 2L))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.INSUFFICIENT_OPEN_COUNT.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("이미 열람한 프로필은 열람권 차감 없이 연락처를 반환한다")
+        void openContact_alreadyViewed() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .bonusOpenCount(0)
+                    .build();
+
+            MeetingProfile target = MeetingProfile.builder()
+                    .kakaoId("kakao-2")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(2001)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("insta_contact")
+                    .bonusOpenCount(0)
+                    .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
+            ReflectionTestUtils.setField(target, "id", 2L);
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+            given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(true);
+
+            MeetingContactResponse result = meetingProfileService.openContact(meetingAuthUser, 2L);
+
+            assertThat(result.contact()).isEqualTo("insta_contact");
+            assertThat(result.alreadyViewed()).isTrue();
+            verify(meetingOpenCountService, org.mockito.Mockito.never()).startCooldown("kakao-1");
         }
 
         @Test

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -469,6 +469,8 @@ class MeetingProfileServiceTest {
 
             meetingProfileService.deleteMeetingProfile(1L);
 
+            verify(contactViewHistoryRepository).deleteByViewerId(1L);
+            verify(contactViewHistoryRepository).deleteByTargetId(1L);
             verify(meetingProfileRepository).delete(profile);
         }
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #166

---

## 📝 주요 변경 내용

- 연락처 열람 이력 엔터티 추가
- 이미 열람한 프로필 재열람 시 열람권 미차감

---

## 🛠️ 작업 상세 내역

- 열람 이력을 DB에 저장하여 중복 열람 여부 판단
- 최초 열람 시에만 열람권 차감 및 이력 저장, 재열람 시 연락처와 alreadyViewed: true 반환
- 응답에 alreadyViewed 필드 추가하여 프론트에서 UI 구분 가능

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---