### PR TITLE
feat: 추천인 링크를 통한 신규 유저 가입 시 추천인에게 보너스 열람권 지급 기능 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthController.java
@@ -57,11 +57,12 @@ public class MeetingAuthController implements MeetingAuthControllerSwagger{
     public ResponseEntity<CommonResponse<LoginResponse>> signUp(
             @Parameter(description = "회원가입용 임시 토큰", required = true)
             @RequestHeader("Authorization") String authHeader,
-            @Valid @RequestBody MeetingSignUpRequest request) {
+            @Valid @RequestBody MeetingSignUpRequest request,
+            @RequestParam(required = false) String ref) {
 
         String signUpToken = jwtTokenExtractor.extractToken(authHeader);
 
-        LoginResponse response = meetingSignUpService.signUp(signUpToken, request);
+        LoginResponse response = meetingSignUpService.signUp(signUpToken, request, ref);
         return CommonResponse.of(HttpStatus.CREATED, "회원가입 완료", response);
     }
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingAuthControllerSwagger.java
@@ -13,6 +13,7 @@ import org.example.sejonglifebe.meeting.dto.StateResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Meeting Auth", description = "미팅 서비스 인증 (카카오 로그인)")
 public interface MeetingAuthControllerSwagger {
@@ -37,6 +38,7 @@ public interface MeetingAuthControllerSwagger {
     ResponseEntity<CommonResponse<LoginResponse>> signUp(
             @Parameter(description = "회원가입용 임시 토큰", required = true)
             @RequestHeader("Authorization") String authHeader,
-            @Valid @RequestBody MeetingSignUpRequest request);
+            @Valid @RequestBody MeetingSignUpRequest request,
+            @RequestParam(required = false) String ref);
 
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -21,16 +21,13 @@ public class MeetingSignUpService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public LoginResponse signUp(String signUpToken, MeetingSignUpRequest request) {
-        // 1. signUpToken 검증 및 kakaoId 추출
+    public LoginResponse signUp(String signUpToken, MeetingSignUpRequest request, String ref) {
         String kakaoId = jwtTokenProvider.validateMeetingSignUpToken(signUpToken);
 
-        // 2. 이미 가입된 사용자인지 확인
         if (meetingProfileRepository.existsByKakaoId(kakaoId)) {
             throw new SejongLifeException(ErrorCode.ALREADY_EXIST_USER);
         }
 
-        // 3. MeetingProfile 생성 및 저장
         MeetingProfile meetingProfile = MeetingProfile.builder()
                 .kakaoId(kakaoId)
                 .gender(request.gender())
@@ -43,8 +40,20 @@ public class MeetingSignUpService {
 
         meetingProfileRepository.save(meetingProfile);
 
-        // 4. 최종 JWT 토큰 발급 (미팅 전용)
+        rewardRecommender(kakaoId, ref);
+
         String accessToken = jwtTokenProvider.createMeetingToken(kakaoId);
         return LoginResponse.loginSuccess(accessToken);
+    }
+
+    private void rewardRecommender(String newUserKakaoId, String recommendId) {
+        if (recommendId == null || recommendId.isBlank()) {
+            return;
+        }
+        if (recommendId.equals(newUserKakaoId)) {
+            return;
+        }
+        meetingProfileRepository.findByKakaoIdWithLock(recommendId)
+                .ifPresent(MeetingProfile::increaseBonusOpenCount);
     }
 }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingSignUpServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingSignUpServiceTest.java
@@ -1,0 +1,132 @@
+package org.example.sejonglifebe.meeting;
+
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.example.sejonglifebe.meeting.entity.FaceType;
+import org.example.sejonglifebe.meeting.entity.Gender;
+import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.service.MeetingSignUpService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingSignUpServiceTest {
+
+    @Mock
+    private MeetingProfileRepository meetingProfileRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private MeetingSignUpService meetingSignUpService;
+
+    private MeetingSignUpRequest buildRequest() {
+        return new MeetingSignUpRequest(
+                Gender.MALE,
+                FaceType.DOG,
+                2000,
+                "축구",
+                "활동적인 데이트",
+                "010-1234-5678"
+        );
+    }
+
+    @Nested
+    @DisplayName("회원가입")
+    class SignUpTest {
+
+        @Test
+        @DisplayName("ref 없이 가입하면 정상적으로 토큰을 발급한다")
+        void signUp_success_withoutRef() {
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(false);
+            given(jwtTokenProvider.createMeetingToken("kakao-1")).willReturn("accessToken");
+
+            LoginResponse response = meetingSignUpService.signUp("signUpToken", buildRequest(), null);
+
+            assertThat(response.getAccessToken()).isEqualTo("accessToken");
+            verify(meetingProfileRepository, never()).findByKakaoIdWithLock(any());
+        }
+
+        @Test
+        @DisplayName("유효한 ref로 가입하면 추천인의 보너스 열람권이 1 증가한다")
+        void signUp_success_rewardRecommender() {
+            MeetingProfile recommender = MeetingProfile.builder()
+                    .kakaoId("kakao-recommender")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(1999)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("contact")
+                    .bonusOpenCount(0)
+                    .build();
+
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(false);
+            given(jwtTokenProvider.createMeetingToken("kakao-1")).willReturn("accessToken");
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-recommender"))
+                    .willReturn(Optional.of(recommender));
+
+            meetingSignUpService.signUp("signUpToken", buildRequest(), "kakao-recommender");
+
+            assertThat(recommender.getBonusOpenCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ref로 가입해도 정상 가입된다")
+        void signUp_success_invalidRef() {
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(false);
+            given(jwtTokenProvider.createMeetingToken("kakao-1")).willReturn("accessToken");
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-unknown"))
+                    .willReturn(Optional.empty());
+
+            LoginResponse response = meetingSignUpService.signUp("signUpToken", buildRequest(), "kakao-unknown");
+
+            assertThat(response.getAccessToken()).isEqualTo("accessToken");
+        }
+
+        @Test
+        @DisplayName("자기 자신을 ref로 설정하면 보너스 열람권이 지급되지 않는다")
+        void signUp_success_selfRef() {
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(false);
+            given(jwtTokenProvider.createMeetingToken("kakao-1")).willReturn("accessToken");
+
+            meetingSignUpService.signUp("signUpToken", buildRequest(), "kakao-1");
+
+            verify(meetingProfileRepository, never()).findByKakaoIdWithLock(any());
+        }
+
+        @Test
+        @DisplayName("이미 가입된 사용자는 예외를 던진다")
+        void signUp_fail_alreadyExist() {
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(true);
+
+            assertThatThrownBy(() -> meetingSignUpService.signUp("signUpToken", buildRequest(), null))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.ALREADY_EXIST_USER.getErrorMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #168 

---

## 📝 주요 변경 내용

-  추천인 링크(?ref=카카오ID)를 통해 신규 유저가 가입 완료 시, 추천인의 보너스 열람권이 1개 증가하는 기능을 구현했습니다.

---

## 🛠️ 작업 상세 내역

  추천인 보상 로직 추가 (`MeetingSignUpService`)
  - signUp()에 String ref 파라미터 추가
  - `rewardRecommender()` 메서드 구현
    - ref가 null/blank인 경우 → 보상 없이 정상 가입 처리
    - ref가 신규 유저 본인의 kakaoId인 경우 → 자기 자신 추천 방지
    - 유효한 추천인인 경우 → 비관적 락으로 조회 후 `increaseBonusOpenCount()` 호출

  회원가입 API에 ref 쿼리 파라미터 추가 (MeetingAuthController, MeetingAuthControllerSwagger)
  - `POST` `/api/meeting/auth/signup?ref={추천인카카오ID}`
  - `required = false`로 설정 -> ref 없이도 가입 정상 처리

  테스트 작성 (MeetingSignUpServiceTest)
  - ref 없이 가입 → 정상 토큰 발급
  - 유효한 ref로 가입 → 추천인 bonusOpenCount +1
  - 존재하지 않는 ref로 가입 → 정상 가입 (보상 없음)
  - 자기 자신을 ref로 설정 → 보상 없음
  - 이미 가입된 유저 → 예외
---

  유저 시나리오
  - 추천인 A (기존 유저)
     1. 초대 링크 공유 (sejonglife.site?ref=A의카카오ID)
     2. 친구 B가 해당 링크로 가입 완료 시 보너스 열람권 +1 지급

  - 신규 유저 B
     1. A의 초대 링크 클릭 → 카카오 로그인 → 프로필 등록 완료
     2. ref 유무와 관계없이 가입은 항상 정상 처리

  시스템 시나리오
  1. 카카오 로그인 → signUpToken 발급
  2. POST /api/meeting/auth/signup?ref=A의카카오ID 요청
  3. 백엔드: signUpToken 검증 → 중복 가입 확인 → MeetingProfile 저장
  4. rewardRecommender() 실행 → 추천인 조회(비관적 락) → bonusOpenCount +1
  5. 신규 유저 accessToken 발급 후 반환

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- rewardRecommender()에서 추천인 조회 시 비관적 락을 사용했습니다.  동일 추천 링크로 여러 신규 유저가 동시에 가입할 경우 bonusOpenCount 동시성 문제를 방지할 수 있스ㅂ니다.
- 추천인이 존재하지 않거나 자기 자신인 경우 예외를 던지지 않고 무시하는 방향으로 처리했습니다.

---