### PR TITLE
feat: 미팅 프로필 수 조회 API 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -18,6 +19,11 @@ import java.util.List;
 public class MeetingProfileController implements MeetingProfileControllerSwagger {
 
     private final MeetingProfileService meetingProfileService;
+
+    @GetMapping("/count")
+    public ResponseEntity<MeetingProfileCountResponse> getProfileCount() {
+        return ResponseEntity.ok(meetingProfileService.getProfileCount());
+    }
 
     @GetMapping
     public ResponseEntity<List<MeetingProfileResponse>> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,12 @@ import java.util.List;
 
 @Tag(name = "Meeting Profile", description = "미팅 프로필 관리")
 public interface MeetingProfileControllerSwagger {
+
+    @Operation(
+            summary = "미팅 프로필 수 조회",
+            description = "전체/남성/여성 미팅 프로필 수를 반환합니다."
+    )
+    ResponseEntity<MeetingProfileCountResponse> getProfileCount();
 
     @Operation(
             summary = "미팅 프로필 전체 조회",

--- a/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileCountResponse.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/dto/MeetingProfileCountResponse.java
@@ -1,0 +1,8 @@
+package org.example.sejonglifebe.meeting.dto;
+
+public record MeetingProfileCountResponse(
+        long total,
+        long male,
+        long female
+) {
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingProfileRepository.java
@@ -21,4 +21,6 @@ public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, 
     boolean existsByKakaoId(String kakaoId);
 
     List<MeetingProfile> findByGender(Gender gender);
+
+    long countByGender(Gender gender);
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -6,6 +6,7 @@ import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.ContactViewHistory;
@@ -37,6 +38,12 @@ public class MeetingProfileService {
         int availableCount = remaining == 0 ? 1 : 0;
 
         return new MeetingOpenCountResponse(availableCount, profile.getBonusOpenCount(), remaining);
+    }
+
+    public MeetingProfileCountResponse getProfileCount() {
+        long male = meetingProfileRepository.countByGender(Gender.MALE);
+        long female = meetingProfileRepository.countByGender(Gender.FEMALE);
+        return new MeetingProfileCountResponse(male + female, male, female);
     }
 
     public List<MeetingProfileResponse> getAllMeetingProfiles(MeetingAuthUser meetingAuthUser) {

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -5,6 +5,7 @@ import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.meeting.dto.MeetingContactResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingAuthUser;
 import org.example.sejonglifebe.meeting.dto.MeetingOpenCountResponse;
+import org.example.sejonglifebe.meeting.dto.MeetingProfileCountResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileResponse;
 import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.FaceType;
@@ -52,6 +53,24 @@ class MeetingProfileServiceTest {
 
     @InjectMocks
     private MeetingProfileService meetingProfileService;
+
+    @Nested
+    @DisplayName("프로필 수 조회")
+    class GetProfileCountTest {
+
+        @Test
+        @DisplayName("남/녀/전체 프로필 수를 반환한다")
+        void getProfileCount_success() {
+            given(meetingProfileRepository.countByGender(Gender.MALE)).willReturn(80L);
+            given(meetingProfileRepository.countByGender(Gender.FEMALE)).willReturn(70L);
+
+            MeetingProfileCountResponse result = meetingProfileService.getProfileCount();
+
+            assertThat(result.total()).isEqualTo(150L);
+            assertThat(result.male()).isEqualTo(80L);
+            assertThat(result.female()).isEqualTo(70L);
+        }
+    }
 
     @Nested
     @DisplayName("전체 조회")


### PR DESCRIPTION

## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #172 

---

## 📝 주요 변경 내용

- 미팅 프로필 수 조회 API 추가 (`GET` `/api/meeting/profiles/count`)
- 파라미터 없이 전체/남성/여성 프로필 수를 한 번에 반환

---

## 🛠️ 작업 상세 내역

  - MeetingProfileCountResponse DTO 추가 (total, male, female)
  - MeetingProfileRepository에 countByGender 메서드 추가
  - MeetingProfileService에 getProfileCount() 로직 구현
  - MeetingProfileController에 GET /count 엔드포인트 추가
  - Swagger 명세 추가 및 서비스 단위 테스트 작성

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- total(전체 프로필 개수)을 DB에서 count(*) 한 번으로 가져오는 대신 countByGender 두 번 호출 후 합산하는 방식으로 해두었습니다!

---