### PR TITLE
refactor: 기본 열람권 먼저 사용하도록 로직 수정

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
@@ -38,7 +38,7 @@ public interface MeetingProfileControllerSwagger {
 
     @Operation(
             summary = "연락처 열람",
-            description = "열람권을 사용해 상대방의 연락처를 조회합니다. 보너스 열람권을 먼저 차감하며, 보너스가 없고 쿨다운이 끝났으면 쿨다운을 시작하고 연락처를 반환합니다."
+            description = "열람권을 사용해 상대방의 연락처를 조회합니다. 쿨다운이 끝났으면 기본 열람권을 먼저 사용하고, 쿨다운 중이면 보너스 열람권을 차감합니다. 열람권이 모두 없으면 예외를 반환합니다."
     )
     ResponseEntity<MeetingContactResponse> openContact(
             MeetingAuthUser meetingAuthUser,

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -88,10 +88,10 @@ public class MeetingProfileService {
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
         if (!alreadyViewed) {
-            if (requester.hasBonusOpenCount()) {
-                requester.decreaseBonusOpenCount();
-            } else if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
+            if (meetingOpenCountService.isRechargeable(meetingAuthUser.kakaoId())) {
                 eventPublisher.publishEvent(new CooldownStartEvent(meetingAuthUser.kakaoId()));
+            } else if (requester.hasBonusOpenCount()) {
+                requester.decreaseBonusOpenCount();
             } else {
                 throw new SejongLifeException(ErrorCode.INSUFFICIENT_OPEN_COUNT);
             }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -273,6 +273,50 @@ class MeetingProfileServiceTest {
         }
 
         @Test
+        @DisplayName("보너스 열람권이 있어도 기본 열람권이 있으면 기본 열람권을 먼저 사용한다")
+        void openContact_success_basicUsedBeforeBonus() {
+            MeetingProfile requester = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("requester_contact")
+                    .bonusOpenCount(1)
+                    .build();
+
+            MeetingProfile target = MeetingProfile.builder()
+                    .kakaoId("kakao-2")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(2001)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("insta_contact")
+                    .bonusOpenCount(0)
+                    .build();
+
+            ReflectionTestUtils.setField(requester, "id", 1L);
+            ReflectionTestUtils.setField(target, "id", 2L);
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
+            given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
+            given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(false);
+            given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(true);
+
+            meetingProfileService.openContact(meetingAuthUser, 2L);
+
+            assertThat(requester.getBonusOpenCount()).isEqualTo(1);
+
+            ArgumentCaptor<CooldownStartEvent> captor = ArgumentCaptor.forClass(CooldownStartEvent.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            assertThat(captor.getValue().kakaoId()).isEqualTo("kakao-1");
+        }
+
+        @Test
         @DisplayName("열람권이 없고 쿨다운 중이면 예외를 던진다")
         void openContact_fail_insufficientOpenCount() {
             MeetingProfile requester = MeetingProfile.builder()

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -233,8 +233,8 @@ class MeetingProfileServiceTest {
         }
 
         @Test
-        @DisplayName("보너스 열람권이 있을 때 보너스 열람권을 먼저 차감한다")
-        void openContact_success_bonusFirst() {
+        @DisplayName("쿨다운 중이고 보너스 열람권이 있을 때 보너스 열람권을 차감한다")
+        void openContact_success_bonusUsedDuringCooldown() {
             MeetingProfile requester = MeetingProfile.builder()
                     .kakaoId("kakao-1")
                     .gender(Gender.MALE)
@@ -265,6 +265,7 @@ class MeetingProfileServiceTest {
             given(meetingProfileRepository.findByKakaoIdWithLock("kakao-1")).willReturn(Optional.of(requester));
             given(meetingProfileRepository.findById(2L)).willReturn(Optional.of(target));
             given(contactViewHistoryRepository.existsByViewerIdAndTargetId(1L, 2L)).willReturn(false);
+            given(meetingOpenCountService.isRechargeable("kakao-1")).willReturn(false);
 
             meetingProfileService.openContact(meetingAuthUser, 2L);
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #174 

---

## 📝 주요 변경 내용

  - 연락처 열람 시 기본 열람권(쿨다운 기반)을 보너스 열람권보다 먼저 사용하도록 우선순위 변경했습니다.
---

## 🛠️ 작업 상세 내역

-
-

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---