### PR TITLE
feat: 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileController.java
@@ -49,6 +49,12 @@ public class MeetingProfileController implements MeetingProfileControllerSwagger
         return ResponseEntity.noContent().build();
     }
 
+    @DeleteMapping("")
+    public ResponseEntity<Void> deleteMyMeetingProfile(MeetingAuthUser meetingAuthUser) {
+        meetingProfileService.deleteMyMeetingProfile(meetingAuthUser);
+        return ResponseEntity.noContent().build();
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateMeetingProfile(
             @PathVariable Long id,

--- a/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/controller/MeetingProfileControllerSwagger.java
@@ -57,6 +57,12 @@ public interface MeetingProfileControllerSwagger {
     );
 
     @Operation(
+            summary = "미팅 회원 탈퇴",
+            description = "토큰 기반으로 본인의 미팅 프로필을 삭제합니다."
+    )
+    ResponseEntity<Void> deleteMyMeetingProfile(MeetingAuthUser meetingAuthUser);
+
+    @Operation(
             summary = "미팅 프로필 삭제",
             description = "미팅 프로필을 삭제합니다."
     )

--- a/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingWithdrawal.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/entity/MeetingWithdrawal.java
@@ -1,0 +1,35 @@
+package org.example.sejonglifebe.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_withdrawals")
+public class MeetingWithdrawal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "kakao_id", nullable = false, unique = true)
+    private String kakaoId;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime withdrawnAt;
+
+    @Builder
+    public MeetingWithdrawal(String kakaoId) {
+        this.kakaoId = kakaoId;
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingWithdrawalRepository.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/repository/MeetingWithdrawalRepository.java
@@ -1,0 +1,9 @@
+package org.example.sejonglifebe.meeting.repository;
+
+import org.example.sejonglifebe.meeting.entity.MeetingWithdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingWithdrawalRepository extends JpaRepository<MeetingWithdrawal, Long> {
+
+    boolean existsByKakaoId(String kakaoId);
+}

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingProfileService.java
@@ -12,8 +12,10 @@ import org.example.sejonglifebe.meeting.dto.MeetingProfileUpdateRequest;
 import org.example.sejonglifebe.meeting.entity.ContactViewHistory;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
+import org.example.sejonglifebe.meeting.entity.MeetingWithdrawal;
 import org.example.sejonglifebe.meeting.repository.ContactViewHistoryRepository;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.repository.MeetingWithdrawalRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,7 @@ public class MeetingProfileService {
 
     private final MeetingProfileRepository meetingProfileRepository;
     private final ContactViewHistoryRepository contactViewHistoryRepository;
+    private final MeetingWithdrawalRepository meetingWithdrawalRepository;
     private final MeetingOpenCountService meetingOpenCountService;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -109,12 +112,36 @@ public class MeetingProfileService {
     }
 
     @Transactional
+    public void deleteMyMeetingProfile(MeetingAuthUser meetingAuthUser) {
+        MeetingProfile profile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        contactViewHistoryRepository.deleteByViewerId(profile.getId());
+        contactViewHistoryRepository.deleteByTargetId(profile.getId());
+        meetingProfileRepository.delete(profile);
+        meetingWithdrawalRepository.save(
+                MeetingWithdrawal.builder()
+                .kakaoId(meetingAuthUser.kakaoId())
+                .build());
+    }
+
+    @Transactional
     public void deleteMeetingProfile(Long id) {
         MeetingProfile profile = meetingProfileRepository.findById(id)
                 .orElseThrow(() -> new SejongLifeException(ErrorCode.MEETING_PROFILE_NOT_FOUND));
 
         contactViewHistoryRepository.deleteByViewerId(id);
         contactViewHistoryRepository.deleteByTargetId(id);
+        meetingProfileRepository.delete(profile);
+    }
+
+    @Transactional
+    public void withdrawMeetingProfile(MeetingAuthUser meetingAuthUser) {
+        MeetingProfile profile = meetingProfileRepository.findByKakaoId(meetingAuthUser.kakaoId())
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        contactViewHistoryRepository.deleteByViewerId(profile.getId());
+        contactViewHistoryRepository.deleteByTargetId(profile.getId());
         meetingProfileRepository.delete(profile);
     }
 }

--- a/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
+++ b/src/main/java/org/example/sejonglifebe/meeting/service/MeetingSignUpService.java
@@ -6,9 +6,10 @@ import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
-import org.example.sejonglifebe.meeting.dto.MeetingSignUpRequest;
+import org.example.sejonglifebe.meeting.repository.MeetingWithdrawalRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingSignUpService {
 
     private final MeetingProfileRepository meetingProfileRepository;
+    private final MeetingWithdrawalRepository meetingWithdrawalRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
@@ -51,6 +53,9 @@ public class MeetingSignUpService {
             return;
         }
         if (recommendId.equals(newUserKakaoId)) {
+            return;
+        }
+        if (meetingWithdrawalRepository.existsByKakaoId(newUserKakaoId)) {
             return;
         }
         meetingProfileRepository.findByKakaoIdWithLock(recommendId)

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingProfileServiceTest.java
@@ -13,6 +13,7 @@ import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.ContactViewHistoryRepository;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.repository.MeetingWithdrawalRepository;
 import org.example.sejonglifebe.meeting.service.CooldownStartEvent;
 import org.example.sejonglifebe.meeting.service.MeetingOpenCountService;
 import org.example.sejonglifebe.meeting.service.MeetingProfileService;
@@ -33,6 +34,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -44,6 +46,9 @@ class MeetingProfileServiceTest {
 
     @Mock
     private ContactViewHistoryRepository contactViewHistoryRepository;
+
+    @Mock
+    private MeetingWithdrawalRepository meetingWithdrawalRepository;
 
     @Mock
     private MeetingOpenCountService meetingOpenCountService;
@@ -511,7 +516,7 @@ class MeetingProfileServiceTest {
     }
 
     @Nested
-    @DisplayName("삭제")
+    @DisplayName("삭제 (관리자)")
     class DeleteMeetingProfileTest {
 
         @Test
@@ -546,6 +551,50 @@ class MeetingProfileServiceTest {
             assertThatThrownBy(() -> meetingProfileService.deleteMeetingProfile(999L))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.MEETING_PROFILE_NOT_FOUND.getErrorMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class DeleteMyMeetingProfileTest {
+
+        @Test
+        @DisplayName("탈퇴 시 ContactViewHistory를 삭제하고 탈퇴 이력을 저장한다")
+        void deleteMyMeetingProfile_success() {
+            MeetingProfile profile = MeetingProfile.builder()
+                    .kakaoId("kakao-1")
+                    .gender(Gender.MALE)
+                    .faceType(FaceType.DOG)
+                    .birthYear(2000)
+                    .hobby("축구")
+                    .dateStyle("활동적인 데이트")
+                    .contact("contact1")
+                    .build();
+
+            ReflectionTestUtils.setField(profile, "id", 1L);
+
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-1");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-1")).willReturn(Optional.of(profile));
+
+            meetingProfileService.deleteMyMeetingProfile(meetingAuthUser);
+
+            verify(contactViewHistoryRepository).deleteByViewerId(1L);
+            verify(contactViewHistoryRepository).deleteByTargetId(1L);
+            verify(meetingProfileRepository).delete(profile);
+            verify(meetingWithdrawalRepository).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저가 탈퇴 시 예외를 던진다")
+        void deleteMyMeetingProfile_fail_notFound() {
+            MeetingAuthUser meetingAuthUser = new MeetingAuthUser("kakao-999");
+
+            given(meetingProfileRepository.findByKakaoId("kakao-999")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> meetingProfileService.deleteMyMeetingProfile(meetingAuthUser))
+                    .isInstanceOf(SejongLifeException.class)
+                    .hasMessage(ErrorCode.USER_NOT_FOUND.getErrorMessage());
         }
     }
 }

--- a/src/test/java/org/example/sejonglifebe/meeting/MeetingSignUpServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/meeting/MeetingSignUpServiceTest.java
@@ -9,6 +9,7 @@ import org.example.sejonglifebe.meeting.entity.FaceType;
 import org.example.sejonglifebe.meeting.entity.Gender;
 import org.example.sejonglifebe.meeting.entity.MeetingProfile;
 import org.example.sejonglifebe.meeting.repository.MeetingProfileRepository;
+import org.example.sejonglifebe.meeting.repository.MeetingWithdrawalRepository;
 import org.example.sejonglifebe.meeting.service.MeetingSignUpService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,6 +33,9 @@ class MeetingSignUpServiceTest {
 
     @Mock
     private MeetingProfileRepository meetingProfileRepository;
+
+    @Mock
+    private MeetingWithdrawalRepository meetingWithdrawalRepository;
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
@@ -128,6 +132,31 @@ class MeetingSignUpServiceTest {
             assertThatThrownBy(() -> meetingSignUpService.signUp("signUpToken", buildRequest(), null))
                     .isInstanceOf(SejongLifeException.class)
                     .hasMessage(ErrorCode.ALREADY_EXIST_USER.getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("탈퇴 이력이 있는 유저가 재가입하면 추천인 보상이 지급되지 않는다")
+        void signUp_success_noRewardForRejoiner() {
+            MeetingProfile recommender = MeetingProfile.builder()
+                    .kakaoId("kakao-recommender")
+                    .gender(Gender.FEMALE)
+                    .faceType(FaceType.CAT)
+                    .birthYear(1999)
+                    .hobby("영화")
+                    .dateStyle("조용한 데이트")
+                    .contact("contact")
+                    .bonusOpenCount(0)
+                    .build();
+
+            given(jwtTokenProvider.validateMeetingSignUpToken("signUpToken")).willReturn("kakao-1");
+            given(meetingProfileRepository.existsByKakaoId("kakao-1")).willReturn(false);
+            given(jwtTokenProvider.createMeetingToken("kakao-1")).willReturn("accessToken");
+            given(meetingWithdrawalRepository.existsByKakaoId("kakao-1")).willReturn(true);
+
+            meetingSignUpService.signUp("signUpToken", buildRequest(), "kakao-recommender");
+
+            assertThat(recommender.getBonusOpenCount()).isEqualTo(0);
+            verify(meetingProfileRepository, never()).findByKakaoIdWithLock(any());
         }
     }
 }


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #176 

---

## 📝 주요 변경 내용

- 미팅 서비스 회원 탈퇴 기능을 구현했습니다. 탈퇴한 사용자의 kakaoId는 meeting_withdrawals 테이블에 별도로 보관하여 탈퇴 후 재가입 시 친구 초대 보너스 열람권이 지급되지 않도록 처리했습니다.

---

## 🛠️ 작업 상세 내역

  - 탈퇴 요청 시 해당 사용자의 연락처 열람 이력(contact_view_histories)을 모두 삭제한 뒤 미팅 프로필을 삭제합니다.
  - 탈퇴한 사용자의 kakaoId를 meeting_withdrawals 테이블에 저장합니다.
  - 재가입 시 meeting_withdrawals 테이블을 조회하여 탈퇴 이력이 있으면 추천인에게 보너스 열람권을 지급하지 않습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요? 
```sql

CREATE TABLE meeting_withdrawals (
      id          BIGINT       NOT NULL AUTO_INCREMENT,
      kakao_id    VARCHAR(255) NOT NULL UNIQUE,
      withdrawn_at DATETIME(6) NOT NULL,
      PRIMARY KEY (id)
  );
```
테이블 추가해야합니다

---