### PR TITLE
feat: dev 서버 마이그레이션을 위한 CI/CD 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,89 @@
+name: Deploy new dev Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17.0.12'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Start MySQL & Redis containers
+        run: docker compose up -d --wait
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+      - name: Build and runs Tests
+        run: |
+          ./gradlew build
+        env:
+          SPRING_APPLICATION_NAME: sejong-life-be
+          SPRING_PROFILES_ACTIVE: default
+
+          SPRING_DATASOURCE_DRIVER-CLASS-NAME: com.mysql.cj.jdbc.Driver
+          SPRING_DATASOURCE_URL: jdbc:mysql://localhost:3308/sejong_life_db?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+          SPRING_DATASOURCE_USERNAME: root
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
+
+          SPRING_JPA_HIBERNATE_DDL_AUTO: create
+          SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.MySQLDialect
+          SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL: true
+          SPRING_JPA_PROPERTIES_HIBERNATE_SHOW_SQL: true
+
+          JWT_SECRET: ${{ secrets.JWT_SECRET_KEY }}
+          JWT_EXPIRATION: 3600000
+          JWT_SIGNUP_EXPIRATION: 600000
+
+          CLOUD_AWS_S3_BUCKET: sejong-life-bucket
+          CLOUD_AWS_REGION_STATIC: ap-northeast-2
+
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
+          KAKAO_REST_API_KEY: ${{ secrets.KAKAO_REST_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+
+      - name: Stop MySQL container
+        if: always()
+        run: docker compose down
+
+      - name: Deploy to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_NEW_HOST }}
+          username: ${{ secrets.EC2_NEW_USERNAME }}
+          key: ${{ secrets.EC2_NEW_PRIVATE_KEY }}
+          source: "build/libs/server.jar"
+          target: "~/sejong-life-dev"
+
+      - name: Execute Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_NEW_HOST }}
+          username: ${{ secrets.EC2_NEW_USERNAME }}
+          key: ${{ secrets.EC2_NEW_PRIVATE_KEY }}
+          script: |
+            sudo env \
+              NAVER_CLIENT_ID='${{ secrets.NAVER_CLIENT_ID }}' \
+              NAVER_CLIENT_SECRET='${{ secrets.NAVER_CLIENT_SECRET }}' \
+              KAKAO_REST_API_KEY='${{ secrets.KAKAO_REST_API_KEY }}' \
+              GOOGLE_MAPS_API_KEY='${{ secrets.GOOGLE_MAPS_API_KEY }}' \
+              REDIS_HOST='${{ secrets.REDIS_HOST }}' \
+              REDIS_PORT='6379' \
+              bash /home/ubuntu/sejong-life-dev/deploy-dev.sh

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+JAVA_HOME="/opt/jdk/jdk-17.0.12+7"
+NGINX_CONFIG_PATH=$(readlink /etc/nginx/conf.d/service-env.conf)
+JAR_PATH="/home/ubuntu/sejong-life-dev/build/libs/server.jar"
+CONFIG_PATH="file:/home/ubuntu/sejong-life-dev/"
+
+if [[ -z "$NGINX_CONFIG_PATH" ]]; then
+  echo "Nginx Config Not Found, Set Profile blue"
+  CURRENT_PROFILE="none";
+  PROFILE="blue"
+elif [[ "$NGINX_CONFIG_PATH" == *"blue"* ]]; then
+  CURRENT_PROFILE="blue"
+  PROFILE="green"
+else
+  CURRENT_PROFILE="green"
+  PROFILE="blue"
+fi
+
+
+echo "> Current Profile: $CURRENT_PROFILE"
+echo "> Next Profile: $PROFILE"
+echo ""
+
+echo "Starting new server..."
+echo "Using Java: ${JAVA_HOME}/bin/java"
+${JAVA_HOME}/bin/java -version
+
+nohup ${JAVA_HOME}/bin/java -jar \
+  -Dspring.profiles.active=${PROFILE} \
+  -Dspring.config.location=${CONFIG_PATH} \
+  ${JAR_PATH} > /dev/null 2>&1 &
+
+echo "Health Check"
+
+if [ "$PROFILE" == "blue" ]; then
+    HEALTH_CHECK_PORT=8081
+else
+    HEALTH_CHECK_PORT=8082
+fi
+echo "> Port: $HEALTH_CHECK_PORT"
+echo "> Wait For Start Server..."
+
+RETRY_COUNT=1
+MAX_RETRY_COUNT=24
+
+while [ $RETRY_COUNT -le $MAX_RETRY_COUNT ]
+do
+    echo "> Try Health Check ($RETRY_COUNT / $MAX_RETRY_COUNT)"
+
+    if curl -s http://127.0.0.1:${HEALTH_CHECK_PORT}/actuator/health | grep -q "UP"; then
+        echo "> Health Check Success"
+        break
+    fi
+
+    if [ $RETRY_COUNT -eq $MAX_RETRY_COUNT ]; then
+        echo "> Health Check Failed, Stop Deploy."
+        TARGET_PID=$(pgrep -f "spring.profiles.active=${PROFILE}")
+        if [ ! -z "$TARGET_PID" ]; then
+            kill -15 "$TARGET_PID"
+        fi
+        exit 1
+    fi
+
+    sleep 5
+    RETRY_COUNT=$((RETRY_COUNT+1))
+done
+echo ""
+
+echo "Nginx Traffic Change"
+sudo ln -sf /etc/nginx/conf.d/service-${PROFILE}.conf /etc/nginx/conf.d/service-env.conf
+sudo nginx -s reload
+echo "Traffic Change Complete"
+echo ""
+
+if [ "$CURRENT_PROFILE" != "none" ]; then
+    echo "TERMINATE OLD SERVER($CURRENT_PROFILE)"
+    OLD_PID=$(pgrep -f "spring.profiles.active=${CURRENT_PROFILE}")
+    if [ ! -z "$OLD_PID" ]; then
+        kill -15 "$OLD_PID"
+        sleep 5
+    fi
+fi
+
+echo "Deploy Complete"
+
+exit 0


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #178

---

## 📝 주요 변경 내용

- dev EC2 서버 마이그레이션을 위한 CI/CD 워크플로우 및 배포 스크립트 추가

---

## 🛠️ 작업 상세 내역

- `main` 브랜치 push 시 dev EC2로 blue/green 무중단 배포하는 GitHub Actions 워크플로우(`deploy-main.yml`) 추가
- dev EC2 전용 배포 스크립트(`deploy-dev.sh`) 추가 (기존 prod용 `deploy.sh`와 별도 경로/이름으로 분리)
- dev용 RDS, S3 버킷, IAM 역할, nginx blue/green 설정 등 인프라 준비 완료
---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---