### PR TITLE
fix: SSO 요청 URL을 https로 변경하여 포털 로그인 503 오류 수정

### DIFF
--- a/src/main/java/org/example/sejonglifebe/auth/PortalClient.java
+++ b/src/main/java/org/example/sejonglifebe/auth/PortalClient.java
@@ -22,11 +22,11 @@ import java.util.List;
 public class PortalClient {
 
     private static final String LOGIN_URL = "https://portal.sejong.ac.kr/jsp/login/login_action.jsp";
-    private static final String RETURN_URL = "http://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https%3A%2F%2Fclassic.sejong.ac.kr%2Fclassic%2Findex.do";
+    private static final String RETURN_URL = "https://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https%3A%2F%2Fclassic.sejong.ac.kr%2Fclassic%2Findex.do";
     private static final String HOST = "portal.sejong.ac.kr";
     private static final String REFERER = "https://portal.sejong.ac.kr";
     private static final String COOKIE = "chknos=false";
-    private static final String SSO_URL = "http://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https://classic.sejong.ac.kr/classic/index.do";
+    private static final String SSO_URL = "https://classic.sejong.ac.kr/_custom/sejong/sso/sso-return.jsp?returnUrl=https://classic.sejong.ac.kr/classic/index.do";
     private static final String HTML_URL = "https://classic.sejong.ac.kr/classic/reading/status.do";
 
     private static final int RETRY_COUNT = 3;


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #182 

---

## 📝 주요 변경 내용
## 문제상황
 로그인이 실패하는 문제가 있었습니다.
<img width="436" height="76" alt="image" src="https://github.com/user-attachments/assets/d021842c-c623-4383-a6ea-6c82312fa3f7" />

로그를 확인해보니  SSO 요청이 503 Service Unavailable로 실패하여 포털 로그인이 안 되었습니다.

## 원인 분석 

- 세종대 대휴칼 포털(classic.sejong.ac.kr) 자체는 브라우저로 정상 접속되는 것을 확인했습니다. 학교 서버 전체 장애는 아니었습니다.
- curl로 직접 재현 테스트를 진행한 결과, 동일한 SSO 경로를 http:// 로 요청하면 항상 503이 발생했고 https:// 로 요청하면 항상 303 See Other와 함께 세션 쿠키(CMS_JSESSIONID 등)가 정상 발급되는 것을 확인했습니다.
- 응답 본문이 <html><body><b>Http/1.1 Service Unavailable</b></body></html>인 단순 정적 페이지였던 점을 봤을 때 서버가 해당 경로에 대한 HTTP(80포트) 접속 자체를 막고 있는 것으로 판단했습니다.

## 해결

PortalClient의 SSO_URL, RETURN_URL 두 상수를 https:// 로 변경했습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---