### PR TITLE
feat: dev 서버 배포를 Docker 컨테이너 방식으로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,28 +6,27 @@ on:
       - develop
 
 jobs:
-  deploy:
+  ci:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
+      - name: 체크아웃
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: JDK 17 설정
         uses: actions/setup-java@v4
         with:
           java-version: '17.0.12'
           distribution: 'temurin'
 
-      - name: Grant execute permission for gradlew
+      - name: gradlew 실행 권한 설정
         run: chmod +x ./gradlew
 
-      - name: Start MySQL & Redis containers
+      - name: MySQL & Redis 컨테이너 실행
         run: docker compose up -d --wait
         env:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
-      - name: Build and runs Tests
+      - name: 빌드 및 테스트 실행
         run: |
           ./gradlew build
         env:
@@ -59,31 +58,53 @@ jobs:
           KAKAO_REST_API_KEY: ${{ secrets.KAKAO_REST_API_KEY }}
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
-      - name: Stop MySQL container
+      - name: 컨테이너 종료
         if: always()
         run: docker compose down
 
-      - name: Deploy to EC2
+      - name: 도커 설정
+        uses: docker/setup-buildx-action@v3
+
+      - name: 도커 허브 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESSTOKEN }}
+
+      - name: 도커 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile-dev
+          push: true
+          tags: sejonglife/sejong-life:dev
+
+      - name: 도커 컴포즈 파일 서버 전송
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "build/libs/server.jar"
-          target: "~/sejong-life-dev"
+          source: "docker-compose-dev.yml,deploy.sh"
+          target: "~"
 
-      - name: Execute Server
+
+  cd:
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: 도커 컨테이너 실행
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script: |
-            sudo env \
-              NAVER_CLIENT_ID='${{ secrets.NAVER_CLIENT_ID }}' \
-              NAVER_CLIENT_SECRET='${{ secrets.NAVER_CLIENT_SECRET }}' \
-              KAKAO_REST_API_KEY='${{ secrets.KAKAO_REST_API_KEY }}' \
-              GOOGLE_MAPS_API_KEY='${{ secrets.GOOGLE_MAPS_API_KEY }}' \
-              REDIS_HOST='${{ secrets.REDIS_HOST }}' \
-              REDIS_PORT='6379' \
-              bash /home/ubuntu/sejong-life-dev/deploy.sh
+            cd ~
+            chmod +x deploy.sh
+            export NAVER_CLIENT_ID='${{ secrets.NAVER_CLIENT_ID }}'
+            export NAVER_CLIENT_SECRET='${{ secrets.NAVER_CLIENT_SECRET }}'
+            export KAKAO_REST_API_KEY='${{ secrets.KAKAO_REST_API_KEY }}'
+            export GOOGLE_MAPS_API_KEY='${{ secrets.GOOGLE_MAPS_API_KEY }}'
+            ./deploy.sh
+            

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:17.0.12_7-jre
+WORKDIR /app
+COPY build/libs/server.jar /app/server.jar
+CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/server.jar"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,11 @@
 #!/bin/bash
 
-JAVA_HOME="/opt/jdk/jdk-17.0.12+7"
-NGINX_CONFIG_PATH=$(readlink /etc/nginx/conf.d/service-env.inc)
-JAR_PATH="/home/ubuntu/sejong-life-dev/build/libs/server.jar"
-CONFIG_PATH="file:/home/ubuntu/sejong-life-dev/"
+COMPOSE_FILE="$HOME/docker-compose-dev.yml"
 
-if [[ -z "$NGINX_CONFIG_PATH" ]]; then
-  echo "Nginx Config Not Found, Set Profile blue"
-  CURRENT_PROFILE="none";
-  PROFILE="blue"
-elif [[ "$NGINX_CONFIG_PATH" == *"blue"* ]]; then
+IS_BLUE_EXIST=$(docker ps | grep blue)
+IS_REDIS_EXIST=$(docker ps | grep redis)
+
+if [ -n "$IS_BLUE_EXIST" ]; then
   CURRENT_PROFILE="blue"
   PROFILE="green"
 else
@@ -17,48 +13,46 @@ else
   PROFILE="blue"
 fi
 
-
-echo "> Current Profile: $CURRENT_PROFILE"
-echo "> Next Profile: $PROFILE"
+echo "> 현재 프로필: $CURRENT_PROFILE"
+echo "> 다음 프로필: $PROFILE"
 echo ""
 
-echo "Starting new server..."
-echo "Using Java: ${JAVA_HOME}/bin/java"
-${JAVA_HOME}/bin/java -version
+echo "> 미사용 도커 이미지 삭제"
+docker image prune -f
 
-nohup ${JAVA_HOME}/bin/java -jar \
-  -Dspring.profiles.active=${PROFILE} \
-  -Dspring.config.location=${CONFIG_PATH} \
-  ${JAR_PATH} > /dev/null 2>&1 &
-
-echo "Health Check"
-
-if [ "$PROFILE" == "blue" ]; then
-    HEALTH_CHECK_PORT=8081
-else
-    HEALTH_CHECK_PORT=8082
+echo "> 레디스 확인"
+if [ -z "$IS_REDIS_EXIST" ]; then
+  docker compose -f "${COMPOSE_FILE}" pull redis
+  docker compose -f "${COMPOSE_FILE}" up -d redis
 fi
-echo "> Port: $HEALTH_CHECK_PORT"
-echo "> Wait For Start Server..."
+
+echo "> ${PROFILE} 컨테이너 이미지 pull 및 실행"
+docker compose -f "${COMPOSE_FILE}" pull "${PROFILE}"
+docker compose -f "${COMPOSE_FILE}" up -d "${PROFILE}"
+
+echo "> 헬스체크 시작"
+if [ "$PROFILE" == "blue" ]; then
+    HEALTH_CHECK_PORT=9091
+else
+    HEALTH_CHECK_PORT=9092
+fi
+echo "> 포트: $HEALTH_CHECK_PORT"
 
 RETRY_COUNT=1
 MAX_RETRY_COUNT=24
 
 while [ $RETRY_COUNT -le $MAX_RETRY_COUNT ]
 do
-    echo "> Try Health Check ($RETRY_COUNT / $MAX_RETRY_COUNT)"
+    echo "> 헬스체크 진행중 ($RETRY_COUNT / $MAX_RETRY_COUNT)"
 
     if curl -s http://127.0.0.1:${HEALTH_CHECK_PORT}/actuator/health | grep -q "UP"; then
-        echo "> Health Check Success"
+        echo "> 헬스체크 성공"
         break
     fi
 
     if [ $RETRY_COUNT -eq $MAX_RETRY_COUNT ]; then
-        echo "> Health Check Failed, Stop Deploy."
-        TARGET_PID=$(pgrep -f "spring.profiles.active=${PROFILE}")
-        if [ ! -z "$TARGET_PID" ]; then
-            kill -15 "$TARGET_PID"
-        fi
+        echo "> 헬스체크 실패, ${PROFILE} 컨테이너 정지 후 배포 중단"
+        docker compose -f "${COMPOSE_FILE}" stop "${PROFILE}"
         exit 1
     fi
 
@@ -67,21 +61,17 @@ do
 done
 echo ""
 
-echo "Nginx Traffic Change"
+echo "> Nginx 트래픽 전환"
 sudo ln -sf /etc/nginx/conf.d/service-${PROFILE}.inc /etc/nginx/conf.d/service-env.inc
 sudo nginx -s reload
-echo "Traffic Change Complete"
+echo "> 트래픽 전환 완료"
 echo ""
 
 if [ "$CURRENT_PROFILE" != "none" ]; then
-    echo "TERMINATE OLD SERVER($CURRENT_PROFILE)"
-    OLD_PID=$(pgrep -f "spring.profiles.active=${CURRENT_PROFILE}")
-    if [ ! -z "$OLD_PID" ]; then
-        kill -15 "$OLD_PID"
-        sleep 5
-    fi
+    echo "> 이전 서버 종료($CURRENT_PROFILE)"
+    docker compose -f "${COMPOSE_FILE}" stop "${CURRENT_PROFILE}"
 fi
 
-echo "Deploy Complete"
+echo "> 배포 완료"
 
 exit 0

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,45 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: sejong-life-redis
+    hostname: redis
+    ports:
+      - "6379:6379"
+
+  blue:
+    container_name: blue
+    image: sejonglife/sejong-life:dev
+    volumes:
+      - ./application.yml:/app/config/application.yml
+    environment:
+      - NAVER_CLIENT_ID=${NAVER_CLIENT_ID}
+      - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
+      - KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}
+      - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}
+    expose:
+      - 8080
+      - 9091
+    ports:
+      - "8081:8080"
+      - "9091:9091"
+    depends_on:
+      - redis
+
+  green:
+    container_name: green
+    image: sejonglife/sejong-life:dev
+    volumes:
+      - ./application.yml:/app/config/application.yml
+    environment:
+      - NAVER_CLIENT_ID=${NAVER_CLIENT_ID}
+      - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
+      - KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}
+      - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}
+    expose:
+      - 8080
+      - 9091
+    ports:
+      - "8082:8080"
+      - "9092:9091"
+    depends_on:
+      - redis


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #184 

---

## 📝 주요 변경 내용

dev 서버 배포를 `java -jar` 직접 실행에서 **Docker 컨테이너 blue-green 배포**로 전환했습니다.

> 앱을 Docker 이미지로 빌드해 Docker Hub에 올리고 서버는 그 이미지를 받아 컨테이너로 실행합니다.

---

## 🛠️ 작업 상세 내역

### 1. 앱 실행 방식 변경 (JAR → 컨테이너)
기존엔 `server.jar`를 EC2로 전송해 `nohup java -jar`로 직접 실행했습니다. 이제는 이미지를 빌드해 Docker Hub(`sejonglife/sejong-life:dev`)에 push하고, 서버에서 pull해 컨테이너로 실행합니다.

> blue/green도 Spring 프로파일 구분 → 같은 이미지를 두 컨테이너로 띄우고 호스트 포트(8081/8082)로 구분하는 방식으로 변경

### 2. 시크릿을 이미지에 굽지 않고 외부 주입

**[배경]**
이미지에 `application.yml`을 함께 굽으면 이미지에 접근할 수 있는 사람이 `docker run ... cat`으로 시크릿을 그대로 꺼내볼 수 있습니다. private 레포라도 계정 유출이나 public 전환 사고 시 노출 위험이 있습니다.

**[개선]**
설정을 이미지 밖에 두고, `application.yml`은 volume mount로 외부 API 키는 환경변수로 주입하도록 했습니다. 이미지에는 시크릿이 남지 않아 이미지가 유출되어도 시크릿은 안전합니다. 덕분에 이미지가 환경 중립적이라 dev/prod에 같은 이미지를 쓸 수 있습니다.

### 3. Redis를 compose 내부 컨테이너로 전환

**[배경]**
기존엔 외부 Redis(ElastiCache)를 사용해 비용이 발생했습니다.

**[개선]**
Redis를 `docker-compose`에 포함해 EC2 내부 컨테이너로 띄우도록 변경했습니다. 앱은 컨테이너 서비스명(`redis`)으로 접근합니다.

---
### 왜 환경변수를 export로 주입하는가?
- 외부 API 키(naver/kakao/google)는 GitHub Secret에만 값이 있고 `application.yml`에서는 `${}`로 참조만 합니다. 이 참조를 채우려면 **환경변수**가 필요한데, 컨테이너는 호스트와 격리되어 있어 호스트 환경변수를 자동으로 상속받지 못합니다.
- `sudo env`로 넘기는 방식도 가능하지만, sudoers 설정에 따라 환경변수가 초기화될 수 있어 전달이 불확실합니다. 반면 `export`는 자식 프로세스(deploy.sh → docker compose)에 확실히 상속되므로, `export` → compose `environment` → 컨테이너 경로로 전달하도록 했습니다.
- 값이 서버에 파일로 남지 않고 실행 시점의 환경변수로만 존재하므로, `.env` 파일 방식보다 노출 위험이 적다고 판단했습니다.

> 하지만 전달이 되는지는 확실하지 않아서 배포 후 확인해봐야할 것 같아요!


---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

> **배포 전 서버에서 할 것**
> - `~/application.yml` 만들기
> - 기존 JAR 프로세스 끄기 (8081/8082 포트 겹침 방지)
> - 문제 생기면 기존 JAR(`~/sejong-life-dev/`)가 그대로 있으니 컨테이너 내리고 JAR 다시 띄우면 롤백됩니다