### PR TITLE
feat: access token과 refresh toke 동시 발급 기능 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/auth/LoginController.java
+++ b/src/main/java/org/example/sejonglifebe/auth/LoginController.java
@@ -1,7 +1,5 @@
 package org.example.sejonglifebe.auth;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
@@ -24,13 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "Auth", description = "인증/인가")
-public class LoginController {
+public class LoginController implements LoginControllerSwagger {
 
     private final LoginService loginService;
     private final RefreshTokenCookieUtil refreshTokenCookieUtil;
 
-    @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request) {
@@ -45,7 +41,6 @@ public class LoginController {
         return responseBuilder.body(new CommonResponse<>("로그인 성공", response));
     }
 
-    @Operation(summary = "액세스 토큰 재발급", description = "쿠키의 refresh token으로 access token을 재발급합니다.")
     @PostMapping("/reissue")
     public ResponseEntity<CommonResponse<LoginResponse>> reissue(
             @CookieValue(name = "refreshToken", required = false) String refreshToken) {
@@ -61,7 +56,6 @@ public class LoginController {
                 .body(new CommonResponse<>("토큰 재발급 성공", response));
     }
 
-    @Operation(summary = "로그아웃")
     @LoginRequired
     @PostMapping("/logout")
     public ResponseEntity<CommonResponse<Void>> logout(AuthUser authUser) {
@@ -73,7 +67,6 @@ public class LoginController {
                 .body(new CommonResponse<>("로그아웃 성공", null));
     }
 
-    @Operation(summary = "관리자 권한 여부 확인", description = "관리자 권한 여부를 반환합니다")
     @LoginRequired(role = Role.ADMIN)
     @GetMapping("/admin")
     public ResponseEntity<CommonResponse<Void>> checkAdmin(AuthUser authUser) {

--- a/src/main/java/org/example/sejonglifebe/auth/LoginController.java
+++ b/src/main/java/org/example/sejonglifebe/auth/LoginController.java
@@ -7,9 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.auth.dto.LoginRequest;
 import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.user.Role;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,20 +28,49 @@ import org.springframework.web.bind.annotation.RestController;
 public class LoginController {
 
     private final LoginService loginService;
+    private final RefreshTokenCookieUtil refreshTokenCookieUtil;
 
     @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<CommonResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request) {
         LoginResponse response = loginService.login(request);
-        return CommonResponse.of(HttpStatus.OK, "로그인 성공", response);
+
+        ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.status(HttpStatus.OK);
+        if (response.getRefreshToken() != null) {
+            ResponseCookie refreshTokenCookie = refreshTokenCookieUtil.create(response.getRefreshToken());
+            responseBuilder.header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        }
+
+        return responseBuilder.body(new CommonResponse<>("로그인 성공", response));
     }
 
-    @Operation(summary = "로그아웃", description = "클라이언트에서 저장된 토큰을 삭제해주세요.")
+    @Operation(summary = "액세스 토큰 재발급", description = "쿠키의 refresh token으로 access token을 재발급합니다.")
+    @PostMapping("/reissue")
+    public ResponseEntity<CommonResponse<LoginResponse>> reissue(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken) {
+        if (refreshToken == null) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+        }
+
+        LoginResponse response = loginService.reissue(refreshToken);
+        ResponseCookie refreshTokenCookie = refreshTokenCookieUtil.create(response.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(new CommonResponse<>("토큰 재발급 성공", response));
+    }
+
+    @Operation(summary = "로그아웃")
+    @LoginRequired
     @PostMapping("/logout")
-    public ResponseEntity<CommonResponse<Void>> logout() {
-        // 클라이언트 기반 로그아웃 (토큰 삭제는 클라이언트가 처리)
-        return CommonResponse.of(HttpStatus.OK, "로그아웃 성공", null);
+    public ResponseEntity<CommonResponse<Void>> logout(AuthUser authUser) {
+        loginService.logout(authUser.studentId());
+        ResponseCookie expiredCookie = refreshTokenCookieUtil.expire();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+                .body(new CommonResponse<>("로그아웃 성공", null));
     }
 
     @Operation(summary = "관리자 권한 여부 확인", description = "관리자 권한 여부를 반환합니다")

--- a/src/main/java/org/example/sejonglifebe/auth/LoginControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/auth/LoginControllerSwagger.java
@@ -1,0 +1,29 @@
+package org.example.sejonglifebe.auth;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.example.sejonglifebe.auth.dto.LoginRequest;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.dto.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "인증/인가")
+public interface LoginControllerSwagger {
+
+    @Operation(summary = "로그인")
+    ResponseEntity<CommonResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request);
+
+    @Operation(summary = "액세스 토큰 재발급", description = "쿠키의 refresh token으로 access token을 재발급합니다.")
+    ResponseEntity<CommonResponse<LoginResponse>> reissue(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken);
+
+    @Operation(summary = "로그아웃")
+    ResponseEntity<CommonResponse<Void>> logout(AuthUser authUser);
+
+    @Operation(summary = "관리자 권한 여부 확인", description = "관리자 권한 여부를 반환합니다")
+    ResponseEntity<CommonResponse<Void>> checkAdmin(AuthUser authUser);
+}

--- a/src/main/java/org/example/sejonglifebe/auth/LoginService.java
+++ b/src/main/java/org/example/sejonglifebe/auth/LoginService.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.auth.dto.LoginRequest;
 import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.user.User;
 import org.example.sejonglifebe.user.UserService;
 import org.springframework.beans.factory.ObjectProvider;
@@ -21,6 +23,8 @@ public class LoginService {
     private final PortalHtmlParser htmlParser;
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final TokenIssuer tokenIssuer;
 
     public LoginResponse login(LoginRequest request) {
         String html = fetchPortal(request);
@@ -36,13 +40,31 @@ public class LoginService {
             userService.updateStudentProfileIfChanged(user.getId(),
                     studentInfo.getName(), studentInfo.getDepartment());
 
-            String accessToken = jwtTokenProvider.createToken(user);
-            return LoginResponse.loginSuccess(accessToken);
+            return tokenIssuer.issue(user);
         } else {
             // 신규 회원: 회원가입 토큰 발급 후 가입 필요 응답
             String signUpToken = jwtTokenProvider.createSignUpToken(studentInfo);
             return LoginResponse.signUpRequired(signUpToken, studentInfo);
         }
+    }
+
+    public LoginResponse reissue(String refreshToken) {
+        String studentId = jwtTokenProvider.validateRefreshToken(refreshToken);
+
+        if (!refreshTokenService.matches(studentId, refreshToken)) {
+            // 이미 회전되어 폐기된(재사용된) 토큰이거나 위조된 토큰 -> 해당 유저 세션 전체 무효화
+            refreshTokenService.delete(studentId);
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+        }
+
+        User user = userService.findUserByStudentId(studentId)
+                .orElseThrow(() -> new SejongLifeException(ErrorCode.USER_NOT_FOUND));
+
+        return tokenIssuer.issue(user);
+    }
+
+    public void logout(String studentId) {
+        refreshTokenService.delete(studentId);
     }
 
     // 인증 로직

--- a/src/main/java/org/example/sejonglifebe/auth/RefreshTokenCookieUtil.java
+++ b/src/main/java/org/example/sejonglifebe/auth/RefreshTokenCookieUtil.java
@@ -1,0 +1,38 @@
+package org.example.sejonglifebe.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class RefreshTokenCookieUtil {
+
+    private static final String COOKIE_NAME = "refreshToken";
+    private static final String COOKIE_PATH = "/api/auth";
+
+    @Value("${jwt.refresh-expiration:1209600000}")
+    private long refreshExpirationTime;
+
+    @Value("${cookie.secure:true}")
+    private boolean secure;
+
+    public ResponseCookie create(String refreshToken) {
+        return build(refreshToken, Duration.ofMillis(refreshExpirationTime));
+    }
+
+    public ResponseCookie expire() {
+        return build("", Duration.ZERO);
+    }
+
+    private ResponseCookie build(String value, Duration maxAge) {
+        return ResponseCookie.from(COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .path(COOKIE_PATH)
+                .maxAge(maxAge)
+                .build();
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/auth/RefreshTokenService.java
+++ b/src/main/java/org/example/sejonglifebe/auth/RefreshTokenService.java
@@ -1,0 +1,34 @@
+package org.example.sejonglifebe.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String KEY_PREFIX = "refresh:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-expiration:1209600000}")
+    private long refreshExpirationTime;
+
+    public void save(String studentId, String refreshToken) {
+        redisTemplate.opsForValue()
+                .set(KEY_PREFIX + studentId, refreshToken, Duration.ofMillis(refreshExpirationTime));
+    }
+
+    public boolean matches(String studentId, String refreshToken) {
+        String stored = redisTemplate.opsForValue().get(KEY_PREFIX + studentId);
+        return stored != null && stored.equals(refreshToken);
+    }
+
+    public void delete(String studentId) {
+        redisTemplate.delete(KEY_PREFIX + studentId);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/auth/TokenIssuer.java
+++ b/src/main/java/org/example/sejonglifebe/auth/TokenIssuer.java
@@ -1,0 +1,23 @@
+package org.example.sejonglifebe.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.user.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenIssuer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public LoginResponse issue(User user) {
+        String accessToken = jwtTokenProvider.createToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        refreshTokenService.save(user.getStudentId(), refreshToken);
+
+        return LoginResponse.loginSuccessWithRefreshToken(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
+++ b/src/main/java/org/example/sejonglifebe/auth/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package org.example.sejonglifebe.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -24,6 +25,10 @@ public class LoginResponse {
     @Schema(description = "카카오 ID", example = "kakao_123456789")
     private final String kakaoId;
 
+    @Schema(hidden = true)
+    @JsonIgnore
+    private final String refreshToken;
+
     @Schema(description = "신규 회원 기본 정보")
     private final UserInfo userInfo;
 
@@ -46,12 +51,13 @@ public class LoginResponse {
     }
 
     /**
-     * 기존 회원일 때 : 로그인 성공, access token 발급
+     * 기존 회원일 때 : 로그인 성공, access/refresh token 발급 (포털 로그인 전용)
      */
-    public static LoginResponse loginSuccess(String accessToken) {
+    public static LoginResponse loginSuccessWithRefreshToken(String accessToken, String refreshToken) {
         return LoginResponse.builder()
                 .isNewUser(false)
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/example/sejonglifebe/common/jwt/JwtTokenProvider.java
@@ -32,6 +32,9 @@ public class JwtTokenProvider {
     @Value("${jwt.signup-expiration}")
     private long signUpTokenExpirationTime;
 
+    @Value("${jwt.refresh-expiration:1209600000}")
+    private long refreshExpirationTime;
+
     private SecretKey key;
 
     @PostConstruct
@@ -51,6 +54,52 @@ public class JwtTokenProvider {
                 .expiration(expiryDate)
                 .signWith(key)
                 .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshExpirationTime);
+
+        return Jwts.builder()
+                .subject(user.getStudentId())
+                .claim("type", "refresh")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    // refresh token 검증 및 studentId(subject) 추출
+    public String validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            String type = claims.get("type", String.class);
+            if (!"refresh".equals(type)) {
+                throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+            }
+
+            return claims.getSubject();
+
+        } catch (SejongLifeException e) {
+            throw e;
+
+        } catch (ExpiredJwtException e) {
+            throw new SejongLifeException(ErrorCode.EXPIRED_TOKEN);
+
+        } catch (MalformedJwtException e) {
+            throw new SejongLifeException(ErrorCode.MALFORMED_TOKEN);
+
+        } catch (SignatureException e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+
+        } catch (Exception e) {
+            throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
+        }
     }
 
     // 회원가입용 임시 토큰

--- a/src/main/java/org/example/sejonglifebe/user/UserController.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthUser;
 import org.example.sejonglifebe.auth.LoginRequired;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
+import org.example.sejonglifebe.auth.RefreshTokenCookieUtil;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.dto.CommonResponse;
 import org.example.sejonglifebe.common.jwt.JwtTokenExtractor;
 import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
@@ -12,7 +14,9 @@ import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.user.dto.MyPageResponse;
 import org.example.sejonglifebe.user.dto.SignUpRequest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,9 +34,10 @@ public class UserController implements UserControllerSwagger{
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenExtractor jwtTokenExtractor;
+    private final RefreshTokenCookieUtil refreshTokenCookieUtil;
 
     @PostMapping("/signup")
-    public ResponseEntity<CommonResponse<String>> signup(
+    public ResponseEntity<CommonResponse<LoginResponse>> signup(
             @RequestHeader("Authorization") String signUpToken,
             @Valid @RequestBody SignUpRequest request) {
 
@@ -44,8 +49,12 @@ public class UserController implements UserControllerSwagger{
             throw new SejongLifeException(ErrorCode.INVALID_TOKEN);
         }
 
-        String accessToken = userService.createUser(request, portalInfoFromToken);
-        return CommonResponse.of(HttpStatus.CREATED, "회원가입 및 로그인 성공", accessToken);
+        LoginResponse response = userService.createUser(request, portalInfoFromToken);
+        ResponseCookie refreshTokenCookie = refreshTokenCookieUtil.create(response.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(new CommonResponse<>("회원가입 및 로그인 성공", response));
     }
 
     @LoginRequired

--- a/src/main/java/org/example/sejonglifebe/user/UserControllerSwagger.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserControllerSwagger.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.example.sejonglifebe.auth.AuthUser;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.dto.CommonResponse;
 import org.example.sejonglifebe.user.dto.MyPageResponse;
 import org.example.sejonglifebe.user.dto.SignUpRequest;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface UserControllerSwagger {
 
     @Operation(summary = "회원가입")
-    ResponseEntity<CommonResponse<String>> signup(
+    ResponseEntity<CommonResponse<LoginResponse>> signup(
             @RequestHeader("Authorization") String signUpToken,
             @Valid @RequestBody SignUpRequest request);
 

--- a/src/main/java/org/example/sejonglifebe/user/UserService.java
+++ b/src/main/java/org/example/sejonglifebe/user/UserService.java
@@ -3,7 +3,8 @@ package org.example.sejonglifebe.user;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.auth.AuthUser;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
-import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.auth.TokenIssuer;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.place.favorite.FavoritePlaceRepository;
@@ -24,7 +25,7 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenIssuer tokenIssuer;
     private final ReviewRepository reviewRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final FavoritePlaceRepository favoritePlaceRepository;
@@ -36,7 +37,7 @@ public class UserService {
     }
 
     @Transactional
-    public String createUser(SignUpRequest requestDto, PortalStudentInfo portalStudentInfo) {
+    public LoginResponse createUser(SignUpRequest requestDto, PortalStudentInfo portalStudentInfo) {
         if (userRepository.existsByNickname(requestDto.getNickname())) {
             throw new SejongLifeException(ErrorCode.DUPLICATE_NICKNAME);
         }
@@ -50,7 +51,7 @@ public class UserService {
 
         User savedUser = userRepository.save(newUser);
 
-        return jwtTokenProvider.createToken(savedUser);
+        return tokenIssuer.issue(savedUser);
     }
 
     @Transactional

--- a/src/test/java/org/example/sejonglifebe/auth/LoginControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/auth/LoginControllerTest.java
@@ -3,10 +3,14 @@ package org.example.sejonglifebe.auth;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.Cookie;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
 import org.example.sejonglifebe.user.Role;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +31,9 @@ class LoginControllerTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private LoginService loginService;
 
     @Test
     @DisplayName("관리자 권한 확인 성공 - ADMIN이면 200 OK 반환")
@@ -64,6 +71,54 @@ class LoginControllerTest {
     void checkAdmin_fail_whenNoToken() throws Exception {
         mockMvc.perform(get("/api/auth/admin")
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재발급 성공 - refresh token 쿠키가 있으면 새 access/refresh token을 발급하고 쿠키를 갱신한다")
+    void reissue_success_whenRefreshTokenCookiePresent() throws Exception {
+        // given
+        given(loginService.reissue("old-refresh"))
+                .willReturn(LoginResponse.loginSuccessWithRefreshToken("new-access", "new-refresh"));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reissue")
+                        .cookie(new Cookie("refreshToken", "old-refresh")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("new-access"))
+                .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("refreshToken=new-refresh")))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재발급 실패 - refresh token 쿠키가 없으면 401 Unauthorized 반환")
+    void reissue_fail_whenNoRefreshTokenCookie() throws Exception {
+        mockMvc.perform(post("/api/auth/reissue"))
+                .andExpect(status().isUnauthorized())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 - 인증된 사용자면 refresh token을 삭제하고 쿠키를 만료시킨다")
+    void logout_success_whenAuthenticated() throws Exception {
+        // given
+        given(jwtTokenProvider.validateAndGetAuthUser(anyString()))
+                .willReturn(new AuthUser("21011111", Role.USER));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer test-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그아웃 성공"))
+                .andExpect(header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Max-Age=0")))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패 - 토큰이 없으면 401 Unauthorized 반환")
+    void logout_fail_whenNoToken() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
                 .andExpect(status().isUnauthorized())
                 .andDo(print());
     }

--- a/src/test/java/org/example/sejonglifebe/auth/LoginServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/auth/LoginServiceTest.java
@@ -1,0 +1,89 @@
+package org.example.sejonglifebe.auth;
+
+import org.example.sejonglifebe.auth.dto.LoginResponse;
+import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+import org.example.sejonglifebe.user.User;
+import org.example.sejonglifebe.user.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock
+    UserService userService;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    RefreshTokenService refreshTokenService;
+
+    @Mock
+    TokenIssuer tokenIssuer;
+
+    @InjectMocks
+    LoginService loginService;
+
+    @Test
+    @DisplayName("refresh token이 Redis에 저장된 값과 일치하면 access/refresh token을 재발급한다")
+    void reissue_success_whenRefreshTokenMatches() {
+        // given
+        User user = User.builder().studentId("21011111").build();
+        LoginResponse reissued = LoginResponse.loginSuccessWithRefreshToken("new-access", "new-refresh");
+
+        given(jwtTokenProvider.validateRefreshToken("old-refresh")).willReturn("21011111");
+        given(refreshTokenService.matches("21011111", "old-refresh")).willReturn(true);
+        given(userService.findUserByStudentId("21011111")).willReturn(Optional.of(user));
+        given(tokenIssuer.issue(user)).willReturn(reissued);
+
+        // when
+        LoginResponse response = loginService.reissue("old-refresh");
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("new-access");
+        assertThat(response.getRefreshToken()).isEqualTo("new-refresh");
+        verify(refreshTokenService, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("Redis에 저장된 값과 다른(이미 회전되어 폐기된) refresh token이면 세션을 무효화하고 예외를 던진다")
+    void reissue_fail_whenRefreshTokenReused() {
+        // given
+        given(jwtTokenProvider.validateRefreshToken("stale-refresh")).willReturn("21011111");
+        given(refreshTokenService.matches("21011111", "stale-refresh")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> loginService.reissue("stale-refresh"))
+                .isInstanceOf(SejongLifeException.class)
+                .hasMessage(ErrorCode.INVALID_TOKEN.getErrorMessage());
+
+        verify(refreshTokenService).delete("21011111");
+        verify(tokenIssuer, never()).issue(any());
+    }
+
+    @Test
+    @DisplayName("logout은 해당 studentId의 refresh token을 Redis에서 삭제한다")
+    void logout_deletesRefreshToken() {
+        // when
+        loginService.logout("21011111");
+
+        // then
+        verify(refreshTokenService).delete("21011111");
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/auth/RefreshTokenServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/auth/RefreshTokenServiceTest.java
@@ -1,0 +1,88 @@
+package org.example.sejonglifebe.auth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    StringRedisTemplate redisTemplate;
+
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("save는 refresh:{studentId} 키로 TTL과 함께 저장한다")
+    void save_storesWithKeyPrefixAndTtl() {
+        // given
+        ReflectionTestUtils.setField(refreshTokenService, "refreshExpirationTime", 1_000_000L);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        refreshTokenService.save("21011111", "refresh-token-value");
+
+        // then
+        verify(valueOperations).set("refresh:21011111", "refresh-token-value", Duration.ofMillis(1_000_000L));
+    }
+
+    @Test
+    @DisplayName("저장된 토큰과 일치하면 matches는 true를 반환한다")
+    void matches_returnsTrue_whenStoredValueEquals() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("refresh:21011111")).willReturn("stored-token");
+
+        // when & then
+        assertThat(refreshTokenService.matches("21011111", "stored-token")).isTrue();
+    }
+
+    @Test
+    @DisplayName("저장된 토큰과 다르면 matches는 false를 반환한다")
+    void matches_returnsFalse_whenStoredValueDiffers() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("refresh:21011111")).willReturn("stored-token");
+
+        // when & then
+        assertThat(refreshTokenService.matches("21011111", "other-token")).isFalse();
+    }
+
+    @Test
+    @DisplayName("저장된 토큰이 없으면 matches는 false를 반환한다")
+    void matches_returnsFalse_whenNoStoredValue() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(anyString())).willReturn(null);
+
+        // when & then
+        assertThat(refreshTokenService.matches("21011111", "any-token")).isFalse();
+    }
+
+    @Test
+    @DisplayName("delete는 refresh:{studentId} 키를 삭제한다")
+    void delete_removesKey() {
+        // when
+        refreshTokenService.delete("21011111");
+
+        // then
+        verify(redisTemplate).delete("refresh:21011111");
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/user/UserControllerTest.java
+++ b/src/test/java/org/example/sejonglifebe/user/UserControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -71,6 +72,10 @@ class UserControllerTest {
     void setUp() {
         given(jwtTokenProvider.validateAndGetAuthUser(anyString()))
                 .willReturn(new AuthUser("21011111", Role.USER));
+        given(jwtTokenProvider.createToken(any()))
+                .willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(any()))
+                .willReturn("refresh-token");
     }
 
     @Test

--- a/src/test/java/org/example/sejonglifebe/user/UserServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/user/UserServiceTest.java
@@ -2,7 +2,8 @@ package org.example.sejonglifebe.user;
 
 import org.example.sejonglifebe.auth.AuthUser;
 import org.example.sejonglifebe.auth.PortalStudentInfo;
-import org.example.sejonglifebe.common.jwt.JwtTokenProvider;
+import org.example.sejonglifebe.auth.TokenIssuer;
+import org.example.sejonglifebe.auth.dto.LoginResponse;
 import org.example.sejonglifebe.exception.ErrorCode;
 import org.example.sejonglifebe.exception.SejongLifeException;
 import org.example.sejonglifebe.place.entity.Place;
@@ -38,7 +39,7 @@ class UserServiceTest {
     UserRepository userRepository;
 
     @Mock
-    JwtTokenProvider jwtTokenProvider;
+    TokenIssuer tokenIssuer;
 
     @Mock
     ReviewRepository reviewRepository;
@@ -80,7 +81,7 @@ class UserServiceTest {
                     .hasMessage(ErrorCode.DUPLICATE_NICKNAME.getErrorMessage());
 
             verify(userRepository, never()).save(any());
-            verify(jwtTokenProvider, never()).createToken(any());
+            verify(tokenIssuer, never()).issue(any());
         }
 
         @Test
@@ -107,15 +108,17 @@ class UserServiceTest {
                     .nickname("새로 생성된 닉네임")
                     .build();
 
+            LoginResponse expectedResponse = LoginResponse.loginSuccessWithRefreshToken("jwt-token", "refresh-token");
+
             given(userRepository.existsByNickname("새로 생성된 닉네임")).willReturn(false);
             given(userRepository.save(any(User.class))).willReturn(savedUser);
-            given(jwtTokenProvider.createToken(savedUser)).willReturn("jwt-token");
+            given(tokenIssuer.issue(savedUser)).willReturn(expectedResponse);
 
             // when
-            String token = userService.createUser(request, portalInfo);
+            LoginResponse response = userService.createUser(request, portalInfo);
 
             // then
-            assertThat(token).isEqualTo("jwt-token");
+            assertThat(response.getAccessToken()).isEqualTo("jwt-token");
 
             ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
             verify(userRepository).save(userCaptor.capture());
@@ -127,7 +130,7 @@ class UserServiceTest {
             assertThat(toSave.getDepartment()).isEqualTo("컴퓨터공학과");
             assertThat(toSave.getNickname()).isEqualTo("새로 생성된 닉네임");
 
-            verify(jwtTokenProvider).createToken(savedUser);
+            verify(tokenIssuer).issue(savedUser);
         }
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,6 +18,7 @@ jwt:
   secret: test-secret-key-for-testing-purpose-only-1234567890
   expiration: 3600000
   signup-expiration: 600000
+  refresh-expiration: 1209600000
 
 cookie:
   secure: false


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #76
- Closes #77

---

## 📝 주요 변경 내용

- 로그인 응답에서 access token과 refresh token도 함께 발급하도록 변경(기존엔 access token만 생성되었음)
- refresh token은 HttpOnly 쿠키로 전달 (JSON 바디에는 포함하지 않음)
- 재발급 시 access/refresh token을 모두 새로 발급하는 rotation 방식 적용, 재사용 탐지 시 세션 강제 무효화

---

## 🛠️ 작업 상세 내역

- `JwtTokenProvider`: `createRefreshToken`/`validateRefreshToken` 추가 
  - 만료 14일, `type=refresh` 클레임으로 access token과 구분
- `RefreshTokenService`: Redis에 `refresh:{studentId}` 키로 저장/검증/삭제
- `TokenIssuer`: access+refresh 토큰 발급 로직을 한 곳에 모음 — 로그인(`LoginService`)과 회원가입 직후 자동로그인(`UserService`) 양쪽에서 재사용
- `RefreshTokenCookieUtil`: HttpOnly, SameSite=Lax, path=`/api/auth` 쿠키 생성/만료 헬퍼
- `POST /api/auth/reissue` 추가
  - 쿠키의 refresh token이 Redis 저장값과 일치 → access/refresh 모두 재발급(rotation), Redis/쿠키 갱신
  - 불일치(이미 회전되어 폐기됐거나 위조된 토큰인 경우) → 해당 유저의 refresh token을 Redis에서 삭제하고 401 반환
- `POST /api/auth/logout`: 기존엔 아무 동작 없는 no-op였음 -> `@LoginRequired`로 인증을 요구하고 Redis의 refresh token을 삭제 + 쿠키 만료 처리
- `POST /api/users/signup` 응답 타입을 `String`(accessToken) → `LoginResponse`로 변경
  - 로그인과 동일한 응답 형태로 통일, refreshToken 필드는 `@JsonIgnore`로 바디엔 노출 안 됨
- `jwt.refresh-expiration`, `cookie.secure` 값 서버 `application.yml`에 추가 필요, 현재 `@Value`에 기본값(14일 / true)을 같이 넣어둠

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- rotation + 재사용 탐지 로직 (`LoginService.reissue`) 부분에 대한 다른 이슈가 없을지 봐주세요!
- 쿠키 속성(HttpOnly / SameSite=Lax / Secure / path=`/api/auth`)이 올바른지 더블체크 해주세요!
- 로그아웃에 `@LoginRequired`를 새로 요구하게 된 것에 대해 의견 궁금합니다 :)

---