### PR TITLE
refactor: 조회수 중복 방지 TTL 6시간 → 30초로 단축

### DIFF
--- a/src/main/java/org/example/sejonglifebe/place/view/PlaceViewService.java
+++ b/src/main/java/org/example/sejonglifebe/place/view/PlaceViewService.java
@@ -1,21 +1,26 @@
 package org.example.sejonglifebe.place.view;
 
 import java.time.Duration;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class PlaceViewService {
     private final StringRedisTemplate redisTemplate;
-    private static final Duration VIEW_TIME_TO_LIVE = Duration.ofSeconds(30);
+    private final Duration viewTimeToLive;
+
+    public PlaceViewService(StringRedisTemplate redisTemplate,
+                            @Value("${place.view.dedup-ttl:30s}") Duration viewTimeToLive) {
+        this.redisTemplate = redisTemplate;
+        this.viewTimeToLive = viewTimeToLive;
+    }
 
     public boolean recordFirstView(Long placeId, Viewer viewer) {
         String key = buildKey(placeId, viewer);
 
         Boolean ok = redisTemplate.opsForValue()
-                .setIfAbsent(key, "1", VIEW_TIME_TO_LIVE);
+                .setIfAbsent(key, "1", viewTimeToLive);
 
         return Boolean.TRUE.equals(ok);
     }

--- a/src/main/java/org/example/sejonglifebe/place/view/PlaceViewService.java
+++ b/src/main/java/org/example/sejonglifebe/place/view/PlaceViewService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceViewService {
     private final StringRedisTemplate redisTemplate;
-    private static final Duration VIEW_TIME_TO_LIVE = Duration.ofHours(6);
+    private static final Duration VIEW_TIME_TO_LIVE = Duration.ofSeconds(30);
 
     public boolean recordFirstView(Long placeId, Viewer viewer) {
         String key = buildKey(placeId, viewer);


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #189 

---

## 📝 주요 변경 내용

- 기존엔 같은 사용자가 한 번 조회하면 6시간 동안 다시 봐도 조회수가 오르지 않아 실제 방문 대비 조회수가 지나치게 낮게 집계되는 경향이 있었습니다.
- 30초 정도의 짧은 dedup 간격이면 새로고침,연속 클릭 같은 어뷰징은 걸러내면서도 재방문은 조회수에 반영되어 조회수가 실제 관심도에 가깝게 쌓이고 그만큼 리뷰 유입 등 활성화에도 도움이 될 것으로 판단됩니다.

---

## 🛠️ 작업 상세 내역

-
-

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---