### PR TITLE
feat: 장소 목록 정렬 셀렉터 추가 (리뷰순·별점순·조회수순)

### DIFF
--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
@@ -2,6 +2,7 @@ package org.example.sejonglifebe.place;
 
 import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.place.dto.PlaceQueryResult;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
 import org.example.sejonglifebe.tag.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ public interface PlaceRepositoryCustom {
             List<Tag> tags,
             String keyword,
             boolean partnershipOnly,
+            PlaceSortType sort,
             Pageable pageable
     );
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -59,8 +59,8 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long total = queryFactory
-                .select(place.id.countDistinct())
+        long total = queryFactory
+                .select(place.id)
                 .from(place)
                 .leftJoin(place.placeCategories, placeCategory)
                 .leftJoin(place.placeTags, placeTag)
@@ -69,9 +69,12 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                         placeTagIn(tags),
                         filterByPartnership(partnershipOnly)
                 )
-                .fetchOne();
+                .groupBy(place.id)
+                .having(placeTagCountEq(tags))
+                .fetch()
+                .size();
 
-        return new PageImpl<>(content, pageable, total == null ? 0L : total);
+        return new PageImpl<>(content, pageable, total);
     }
 
     private OrderSpecifier<?>[] toOrderSpecifiers(PlaceSortType sort) {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -54,7 +54,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 )
                 .groupBy(place.id)
                 .having(placeTagCountEq(tags))
-                .orderBy(toOrderSpecifier(sort))
+                .orderBy(toOrderSpecifiers(sort))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -74,12 +74,13 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
-    private OrderSpecifier<?> toOrderSpecifier(PlaceSortType sort) {
-        return switch (PlaceSortType.orDefault(sort)) {
+    private OrderSpecifier<?>[] toOrderSpecifiers(PlaceSortType sort) {
+        OrderSpecifier<?> primary = switch (PlaceSortType.orDefault(sort)) {
             case REVIEW_COUNT -> review.countDistinct().desc();
             case RATING -> review.rating.avg().desc();
             case VIEW_COUNT -> place.viewCount.desc();
         };
+        return new OrderSpecifier<?>[]{primary, place.id.asc()};
     }
 
     private BooleanExpression likePlaceName(String keyword) {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -77,7 +77,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     private OrderSpecifier<?>[] toOrderSpecifiers(PlaceSortType sort) {
         OrderSpecifier<?> primary = switch (PlaceSortType.orDefault(sort)) {
             case REVIEW_COUNT -> review.countDistinct().desc();
-            case RATING -> review.rating.avg().desc();
+            case RATING -> review.rating.avg().desc().nullsLast();
             case VIEW_COUNT -> place.viewCount.desc();
         };
         return new OrderSpecifier<?>[]{primary, place.id.asc()};

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.example.sejonglifebe.place;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -8,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.example.sejonglifebe.category.Category;
 import org.example.sejonglifebe.place.dto.PlaceQueryResult;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
 import org.example.sejonglifebe.tag.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,7 +29,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, boolean partnershipOnly, Pageable pageable) {
+    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, boolean partnershipOnly, PlaceSortType sort, Pageable pageable) {
         JPAQuery<PlaceQueryResult> query = queryFactory
                 .select(Projections.constructor(PlaceQueryResult.class,
                         place,
@@ -52,7 +54,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 )
                 .groupBy(place.id)
                 .having(placeTagCountEq(tags))
-                .orderBy(review.countDistinct().desc())
+                .orderBy(toOrderSpecifier(sort))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -70,6 +72,14 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total == null ? 0L : total);
+    }
+
+    private OrderSpecifier<?> toOrderSpecifier(PlaceSortType sort) {
+        return switch (PlaceSortType.orDefault(sort)) {
+            case REVIEW_COUNT -> review.countDistinct().desc();
+            case RATING -> review.rating.avg().desc();
+            case VIEW_COUNT -> place.viewCount.desc();
+        };
     }
 
     private BooleanExpression likePlaceName(String keyword) {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -66,7 +66,7 @@ public class PlaceService {
                     .orElseThrow(() -> new SejongLifeException(ErrorCode.CATEGORY_NOT_FOUND));
         }
 
-        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, conditions.sort(), pageable)
+        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, conditions.sortType(), pageable)
                 .map(PlaceResponse::from);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -66,7 +66,7 @@ public class PlaceService {
                     .orElseThrow(() -> new SejongLifeException(ErrorCode.CATEGORY_NOT_FOUND));
         }
 
-        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, pageable)
+        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, conditions.sort(), pageable)
                 .map(PlaceResponse::from);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
@@ -20,6 +20,9 @@ public record PlaceSearchConditions(
         String keyword,
 
         @Schema(description = "제휴 장소 필터링 여부" , example = "false")
-        boolean partnershipOnly
+        boolean partnershipOnly,
+
+        @Schema(description = "정렬 기준 (미지정 시 REVIEW_COUNT)", example = "REVIEW_COUNT")
+        PlaceSortType sort
 ) {
 }

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
@@ -25,4 +25,7 @@ public record PlaceSearchConditions(
         @Schema(description = "정렬 기준 (미지정 시 REVIEW_COUNT)", example = "REVIEW_COUNT")
         PlaceSortType sort
 ) {
+    public PlaceSearchConditions {
+        sortType = PlaceSortType.orDefault(sortType);
+    }
 }

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
@@ -23,7 +23,7 @@ public record PlaceSearchConditions(
         boolean partnershipOnly,
 
         @Schema(description = "정렬 기준 (미지정 시 REVIEW_COUNT)", example = "REVIEW_COUNT")
-        PlaceSortType sort
+        PlaceSortType sortType
 ) {
     public PlaceSearchConditions {
         sortType = PlaceSortType.orDefault(sortType);

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSortType.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSortType.java
@@ -1,0 +1,11 @@
+package org.example.sejonglifebe.place.dto;
+
+public enum PlaceSortType {
+    REVIEW_COUNT,
+    RATING,
+    VIEW_COUNT;
+
+    public static PlaceSortType orDefault(PlaceSortType sort) {
+        return sort == null ? REVIEW_COUNT : sort;
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
@@ -1,0 +1,76 @@
+package org.example.sejonglifebe.place;
+
+import org.example.sejonglifebe.category.Category;
+import org.example.sejonglifebe.category.CategoryRepository;
+import org.example.sejonglifebe.place.dto.PlaceQueryResult;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
+import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.tag.Tag;
+import org.example.sejonglifebe.tag.TagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PlaceCountQueryTest {
+
+    @Autowired private PlaceRepository placeRepository;
+    @Autowired private TagRepository tagRepository;
+    @Autowired private CategoryRepository categoryRepository;
+
+    private Tag tagA;
+    private Tag tagB;
+
+    @BeforeEach
+    void setUp() {
+        placeRepository.deleteAll();
+        tagRepository.deleteAll();
+        categoryRepository.deleteAll();
+
+        tagA = tagRepository.save(new Tag("가성비"));
+        tagB = tagRepository.save(new Tag("분위기"));
+
+        // A+B 둘 다 가진 장소 2개 (필터 A,B 시 매칭돼야 함)
+        savePlace("둘다1", tagA, tagB);
+        savePlace("둘다2", tagA, tagB);
+        // A만 가진 장소 3개 (필터 A,B 시 제외돼야 함)
+        savePlace("A만1", tagA);
+        savePlace("A만2", tagA);
+        savePlace("A만3", tagA);
+    }
+
+    private void savePlace(String name, Tag... tags) {
+        Place place = Place.createPlace(name, "주소", null, null, null, false, "");
+        for (Tag tag : tags) {
+            place.addTag(tag);
+        }
+        placeRepository.save(place);
+    }
+
+    @Test
+    @DisplayName("태그 여러 개(AND)로 필터 시 totalElements가 전체 일치 장소 수와 일치한다")
+    void totalElements_matchesAllTagFilteredCount() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                null, List.of(tagA, tagB), null, false, PlaceSortType.REVIEW_COUNT, pageable);
+
+        // A+B 둘 다 가진 장소는 2개뿐. A만 가진 3개는 제외돼야 함.
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
@@ -15,6 +15,7 @@ import org.example.sejonglifebe.place.dto.PlaceQueryResult;
 import org.example.sejonglifebe.place.dto.PlaceRequest;
 import org.example.sejonglifebe.place.dto.PlaceResponse;
 import org.example.sejonglifebe.place.dto.PlaceSearchConditions;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
 import org.example.sejonglifebe.place.entity.Place;
 import org.example.sejonglifebe.s3.S3Service;
 import org.example.sejonglifebe.tag.Tag;
@@ -107,7 +108,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -130,7 +131,7 @@ class PlaceServiceTest {
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -173,7 +174,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -198,7 +199,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -223,7 +224,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -247,7 +248,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -269,7 +270,7 @@ class PlaceServiceTest {
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, null, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -293,7 +294,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, null, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, PlaceSortType.REVIEW_COUNT, pageable))
                     .willReturn(pageResult);
 
             // when

--- a/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
@@ -79,7 +79,7 @@ class PlaceServiceTest {
         @DisplayName("존재하지 않는 태그 이름이 포함되면 TAG_NOT_FOUND 예외를 던진다")
         void getPlaces_tagNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(anyList()))
@@ -97,7 +97,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 = 전체 && 태그 없음 → 모든 장소를 조회한다")
         void getPlaces_allCategory_noTags() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("장소1").build();
             Place place2 = Place.builder().name("장소2").build();
@@ -107,7 +107,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -124,13 +124,13 @@ class PlaceServiceTest {
         void getPlaces_allCategory_withTags() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 장소").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -145,7 +145,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 존재하지 않으면 CATEGORY_NOT_FOUND 예외를 던진다")
         void getPlaces_categoryNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
@@ -162,7 +162,7 @@ class PlaceServiceTest {
         void getPlaces_selectedCategory_noTags() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("맛집1").build();
             Place place2 = Place.builder().name("맛집2").build();
@@ -173,7 +173,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -191,14 +191,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null, false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null, false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 맛집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -213,7 +213,7 @@ class PlaceServiceTest {
         @DisplayName("키워드만 입력 → 장소명에 키워드가 포함된 장소를 조회한다")
         void getPlaces_withKeywordOnly() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페", false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페", false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("스타벅스 카페").build();
             Place place2 = Place.builder().name("투썸 카페").build();
@@ -223,7 +223,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -240,14 +240,14 @@ class PlaceServiceTest {
         void getPlaces_withCategoryAndKeyword() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨", false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨", false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("BHC 치킨").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -263,13 +263,13 @@ class PlaceServiceTest {
         void getPlaces_withTagAndKeyword() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자", false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자", false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 피자").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -286,14 +286,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨", false);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨", false, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 치킨집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, null, pageable))
                     .willReturn(pageResult);
 
             // when

--- a/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
@@ -1,0 +1,138 @@
+package org.example.sejonglifebe.place;
+
+import org.example.sejonglifebe.place.dto.PlaceQueryResult;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
+import org.example.sejonglifebe.place.entity.Place;
+import org.example.sejonglifebe.review.Review;
+import org.example.sejonglifebe.review.ReviewRepository;
+import org.example.sejonglifebe.user.User;
+import org.example.sejonglifebe.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class PlaceSortRepositoryTest {
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private final Pageable pageable = PageRequest.of(0, 10);
+
+    private Place placeA; // 리뷰 3개, 평균 별점 5, 조회수 1
+    private Place placeB; // 리뷰 2개, 평균 별점 3, 조회수 10
+    private Place placeC; // 리뷰 0개, 평균 별점 없음, 조회수 5
+
+    @BeforeEach
+    void setUp() {
+        reviewRepository.deleteAll();
+        placeRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User user = userRepository.save(
+                User.builder().studentId("21010001").nickname("테스터").build()
+        );
+
+        placeA = placeRepository.save(newPlace("장소A"));
+        placeB = placeRepository.save(newPlace("장소B"));
+        placeC = placeRepository.save(newPlace("장소C"));
+
+        // 리뷰 개수 & 별점 세팅
+        saveReview(placeA, user, 5);
+        saveReview(placeA, user, 5);
+        saveReview(placeA, user, 5); // A: 3개, 평균 5
+        saveReview(placeB, user, 4);
+        saveReview(placeB, user, 2); // B: 2개, 평균 3
+        // C: 리뷰 없음
+
+        // 조회수 세팅
+        placeRepository.increaseViewCount(placeB.getId()); // B: 10
+        for (int i = 0; i < 9; i++) {
+            placeRepository.increaseViewCount(placeB.getId());
+        }
+        for (int i = 0; i < 5; i++) {
+            placeRepository.increaseViewCount(placeC.getId()); // C: 5
+        }
+        placeRepository.increaseViewCount(placeA.getId()); // A: 1
+    }
+
+    private Place newPlace(String name) {
+        return Place.createPlace(name, "주소", null, null, null, false, "");
+    }
+
+    private void saveReview(Place place, User user, int rating) {
+        Review review = Review.createReview(place, user, rating, "리뷰");
+        reviewRepository.save(review);
+    }
+
+    private List<String> names(Page<PlaceQueryResult> page) {
+        return page.getContent().stream()
+                .map(result -> result.place().getName())
+                .toList();
+    }
+
+    @Nested
+    @DisplayName("정렬 기준별 조회")
+    class SortByType {
+
+        @Test
+        @DisplayName("REVIEW_COUNT: 리뷰 많은 순으로 정렬한다")
+        void sortByReviewCount() {
+            Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                    null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable);
+
+            // A(3) > B(2) > C(0)
+            assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");
+        }
+
+        @Test
+        @DisplayName("RATING: 평균 별점 높은 순으로 정렬하고, 리뷰 없는 장소는 맨 뒤로 보낸다")
+        void sortByRating() {
+            Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                    null, List.of(), null, false, PlaceSortType.RATING, pageable);
+
+            // A(5) > B(3) > C(리뷰 없음 → 맨 뒤)
+            assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");
+        }
+
+        @Test
+        @DisplayName("VIEW_COUNT: 조회수 많은 순으로 정렬한다")
+        void sortByViewCount() {
+            Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                    null, List.of(), null, false, PlaceSortType.VIEW_COUNT, pageable);
+
+            // B(10) > C(5) > A(1)
+            assertThat(names(result)).containsExactly("장소B", "장소C", "장소A");
+        }
+
+        @Test
+        @DisplayName("sort가 null이면 기본값(REVIEW_COUNT)으로 정렬한다")
+        void sortByNull_usesReviewCountDefault() {
+            Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                    null, List.of(), null, false, null, pageable);
+
+            // 기본값 = REVIEW_COUNT → A(3) > B(2) > C(0)
+            assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");
+        }
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/place/dto/PlaceSortTypeTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/dto/PlaceSortTypeTest.java
@@ -1,0 +1,22 @@
+package org.example.sejonglifebe.place.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceSortTypeTest {
+
+    @Test
+    @DisplayName("orDefault: null이면 REVIEW_COUNT를 반환한다")
+    void orDefault_null_returnsReviewCount() {
+        assertThat(PlaceSortType.orDefault(null)).isEqualTo(PlaceSortType.REVIEW_COUNT);
+    }
+
+    @Test
+    @DisplayName("orDefault: null이 아니면 그대로 반환한다")
+    void orDefault_notNull_returnsSame() {
+        assertThat(PlaceSortType.orDefault(PlaceSortType.RATING)).isEqualTo(PlaceSortType.RATING);
+        assertThat(PlaceSortType.orDefault(PlaceSortType.VIEW_COUNT)).isEqualTo(PlaceSortType.VIEW_COUNT);
+    }
+}


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #191 

---

## 📝 주요 변경 내용

- 장소 목록 조회(GET /api/places)에 정렬 셀렉터 추가
- sort 파라미터로 정렬 기준 선택 (미지정 시 리뷰순 = 기존 동작 유지)
  - REVIEW_COUNT : 리뷰 많은 순 (기본값)
  - RATING : 별점 높은 순
  - VIEW_COUNT : 조회수 많은 순

---

## 🛠️ 작업 상세 내역

- sort 파라미터로 정렬 기준을 받아 QueryDSL 정렬 절을 동적으로 구성
- 별점순·리뷰순은 집계값(평균 평점, 리뷰 수)이라 스프링 표준 Sort로는 정렬이 안 됨 → 파라미터를 직접 받는 방식을 선택
- 별점순에서 리뷰 0개 장소가 맨 뒤로 가는지는 통합 테스트로 실측 확인

### 거리순과 좋아요순은 이번 범위에서 제외했습니다.
> - 거리순 : 나머지 3개는 정렬 절만 바꾸면 되는 동일 패턴이지만 거리순은 클라이언트가 사용자 좌표를 넘겨야 하고 좌표 없는 장소, 위치 미제공 사용자에 대한 예외 처리가 필요합니다. 또한 좌표 기반 거리 검색은 Redis GEO 같은 별도 저장소로 처리하는 설계를 검토 중이라 API 계약,정렬 방식이 이번 작업과 완전히 달라 별도 PR로 분리했습니다.

> - 좋아요순 : 좋아요 값이 장소 레벨에 없어(Review에만 존재) 장소 단위 정렬 기준이 명확하지 않아 제외했습니다.
---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---