### PR TITLE
fix: 통합 테스트의 @ActiveProfiles("test") 제거로 CI DB 드라이버 불일치 해결

### DIFF
--- a/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -23,7 +22,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class PlaceCountQueryTest {
 

--- a/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -24,7 +23,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@ActiveProfiles("test")
 @Transactional
 class PlaceSortRepositoryTest {
 


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #193 

---

## 📝 주요 변경 내용

- CI에서 통합 테스트가 실패하던 문제 수정했습니다.

원인: PlaceSortRepositoryTest와 PlaceCountQueryTest가 test 프로파일로 H2를 사용하는데, CI가 주입하는 MySQL URL 환경변수와 충돌이 일어났습니다. 환경변수가 URL은 덮어썼지만 드라이버 설정은 덮지 못해, H2 드라이버로 MySQL URL에 접속하려다 실패했습니다.

> Driver org.h2.Driver claims to not accept jdbcUrl, jdbc:mysql://...

해결: 두 테스트에서 test 프로파일 지정을 제거해 기존 통합 테스트처럼 CI의 MySQL 설정을 그대로 사용하도록 했습니다.

---

## 🛠️ 작업 상세 내역

-
-

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

-

---