### PR TITLE
feat: 장소 목록 거리순 정렬 추가

### DIFF
--- a/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
+++ b/src/main/java/org/example/sejonglifebe/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     REVIEW_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 좋아요입니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "파라미터 형식이 올바르지 않습니다."),
     MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+    DISTANCE_SORT_REQUIRES_LOCATION(HttpStatus.BAD_REQUEST, "거리순 정렬은 사용자 위치가 필요합니다."),
     DUPLICATE_VALUE(HttpStatus.BAD_REQUEST, "중복된 값이 존재합니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     DUPLICATE_LIKE(HttpStatus.CONFLICT, "중복된 좋아요 요청입니다."),

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryCustom.java
@@ -17,6 +17,8 @@ public interface PlaceRepositoryCustom {
             String keyword,
             boolean partnershipOnly,
             PlaceSortType sort,
+            Double latitude,
+            Double longitude,
             Pageable pageable
     );
 }

--- a/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +31,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, boolean partnershipOnly, PlaceSortType sort, Pageable pageable) {
+    public Page<PlaceQueryResult> getPlacesByConditions(Category category, List<Tag> tags, String keyword, boolean partnershipOnly, PlaceSortType sort, Double latitude, Double longitude, Pageable pageable) {
         JPAQuery<PlaceQueryResult> query = queryFactory
                 .select(Projections.constructor(PlaceQueryResult.class,
                         place,
@@ -54,7 +56,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                 )
                 .groupBy(place.id)
                 .having(placeTagCountEq(tags))
-                .orderBy(toOrderSpecifiers(sort))
+                .orderBy(toOrderSpecifiers(sort, latitude, longitude))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -77,13 +79,20 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         return new PageImpl<>(content, pageable, total);
     }
 
-    private OrderSpecifier<?>[] toOrderSpecifiers(PlaceSortType sort) {
+    private OrderSpecifier<?>[] toOrderSpecifiers(PlaceSortType sort, Double latitude, Double longitude) {
         OrderSpecifier<?> primary = switch (PlaceSortType.orDefault(sort)) {
             case REVIEW_COUNT -> review.countDistinct().desc();
             case RATING -> review.rating.avg().desc().nullsLast();
             case VIEW_COUNT -> place.viewCount.desc();
+            case DISTANCE -> distance(latitude, longitude).asc();
         };
         return new OrderSpecifier<?>[]{primary, place.id.asc()};
+    }
+
+    private NumberExpression<Double> distance(Double latitude, Double longitude) {
+        return Expressions.numberTemplate(Double.class,
+                "ST_Distance_Sphere(POINT({0}, {1}), POINT({2}, {3}))",
+                longitude, latitude, place.longitude, place.latitude);
     }
 
     private BooleanExpression likePlaceName(String keyword) {

--- a/src/main/java/org/example/sejonglifebe/place/PlaceService.java
+++ b/src/main/java/org/example/sejonglifebe/place/PlaceService.java
@@ -66,7 +66,7 @@ public class PlaceService {
                     .orElseThrow(() -> new SejongLifeException(ErrorCode.CATEGORY_NOT_FOUND));
         }
 
-        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, conditions.sortType(), pageable)
+        return placeRepository.getPlacesByConditions(category, tags, conditions.keyword(), PartnershipOnly, conditions.sortType(), conditions.latitude(), conditions.longitude(), pageable)
                 .map(PlaceResponse::from);
     }
 

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSearchConditions.java
@@ -2,6 +2,8 @@ package org.example.sejonglifebe.place.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
 import org.springdoc.core.annotations.ParameterObject;
 
 import java.util.List;
@@ -23,9 +25,18 @@ public record PlaceSearchConditions(
         boolean partnershipOnly,
 
         @Schema(description = "정렬 기준 (미지정 시 REVIEW_COUNT)", example = "REVIEW_COUNT")
-        PlaceSortType sortType
+        PlaceSortType sortType,
+
+        @Schema(description = "사용자 위도 (거리순 정렬 시 필수)", example = "37.550838")
+        Double latitude,
+
+        @Schema(description = "사용자 경도 (거리순 정렬 시 필수)", example = "127.074430")
+        Double longitude
 ) {
     public PlaceSearchConditions {
         sortType = PlaceSortType.orDefault(sortType);
+        if (sortType == PlaceSortType.DISTANCE && (latitude == null || longitude == null)) {
+            throw new SejongLifeException(ErrorCode.DISTANCE_SORT_REQUIRES_LOCATION);
+        }
     }
 }

--- a/src/main/java/org/example/sejonglifebe/place/dto/PlaceSortType.java
+++ b/src/main/java/org/example/sejonglifebe/place/dto/PlaceSortType.java
@@ -3,7 +3,8 @@ package org.example.sejonglifebe.place.dto;
 public enum PlaceSortType {
     REVIEW_COUNT,
     RATING,
-    VIEW_COUNT;
+    VIEW_COUNT,
+    DISTANCE;
 
     public static PlaceSortType orDefault(PlaceSortType sort) {
         return sort == null ? REVIEW_COUNT : sort;

--- a/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceCountQueryTest.java
@@ -64,7 +64,7 @@ class PlaceCountQueryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
-                null, List.of(tagA, tagB), null, false, PlaceSortType.REVIEW_COUNT, pageable);
+                null, List.of(tagA, tagB), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable);
 
         // A+B 둘 다 가진 장소는 2개뿐. A만 가진 3개는 제외돼야 함.
         assertThat(result.getContent()).hasSize(2);

--- a/src/test/java/org/example/sejonglifebe/place/PlaceDistanceSortTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceDistanceSortTest.java
@@ -1,0 +1,57 @@
+package org.example.sejonglifebe.place;
+
+import org.example.sejonglifebe.place.dto.PlaceQueryResult;
+import org.example.sejonglifebe.place.dto.PlaceSortType;
+import org.example.sejonglifebe.place.entity.Place;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class PlaceDistanceSortTest {
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    // 기준점: 세종대학교 정문 부근
+    private static final double USER_LATITUDE = 37.550838;
+    private static final double USER_LONGITUDE = 127.074430;
+
+    @BeforeEach
+    void setUp() {
+        placeRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("DISTANCE 정렬은 사용자 위치에서 가까운 순으로 장소를 반환한다")
+    void sortByDistance_nearestFirst() {
+        // 기준점에서: 가까움 → 중간 → 멈 순으로 좌표 배치
+        Place near = savePlace("가까운곳", 37.550900, 127.074500);   // ~수십 m
+        Place mid = savePlace("중간곳", 37.556000, 127.080000);      // ~수백 m
+        Place far = savePlace("먼곳", 37.600000, 127.150000);        // ~수 km
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
+                null, List.of(), null, false, PlaceSortType.DISTANCE, USER_LATITUDE, USER_LONGITUDE, pageable);
+
+        assertThat(result.getContent())
+                .extracting(r -> r.place().getName())
+                .containsExactly("가까운곳", "중간곳", "먼곳");
+    }
+
+    private Place savePlace(String name, double latitude, double longitude) {
+        Place place = Place.createPlace(name, "주소", latitude, longitude, null, false, "");
+        return placeRepository.save(place);
+    }
+}

--- a/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceServiceTest.java
@@ -80,7 +80,7 @@ class PlaceServiceTest {
         @DisplayName("존재하지 않는 태그 이름이 포함되면 TAG_NOT_FOUND 예외를 던진다")
         void getPlaces_tagNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("존재X"), "전체", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(anyList()))
@@ -98,7 +98,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 = 전체 && 태그 없음 → 모든 장소를 조회한다")
         void getPlaces_allCategory_noTags() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("장소1").build();
             Place place2 = Place.builder().name("장소2").build();
@@ -108,7 +108,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -125,13 +125,13 @@ class PlaceServiceTest {
         void getPlaces_allCategory_withTags() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 장소").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -146,7 +146,7 @@ class PlaceServiceTest {
         @DisplayName("카테고리 존재하지 않으면 CATEGORY_NOT_FOUND 예외를 던진다")
         void getPlaces_categoryNotFound() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
@@ -163,7 +163,7 @@ class PlaceServiceTest {
         void getPlaces_selectedCategory_noTags() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("맛집1").build();
             Place place2 = Place.builder().name("맛집2").build();
@@ -174,7 +174,7 @@ class PlaceServiceTest {
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -192,14 +192,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null, false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", null, false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 맛집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -214,7 +214,7 @@ class PlaceServiceTest {
         @DisplayName("키워드만 입력 → 장소명에 키워드가 포함된 장소를 조회한다")
         void getPlaces_withKeywordOnly() {
             // given
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페", false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "전체", "카페", false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("스타벅스 카페").build();
             Place place2 = Place.builder().name("투썸 카페").build();
@@ -224,7 +224,7 @@ class PlaceServiceTest {
             ));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
-            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(), "카페", false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -241,14 +241,14 @@ class PlaceServiceTest {
         void getPlaces_withCategoryAndKeyword() {
             // given
             Category category = new Category("맛집");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨", false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of(), "맛집", "치킨", false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("BHC 치킨").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(List.of())).willReturn(List.of());
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(), "치킨", false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -264,13 +264,13 @@ class PlaceServiceTest {
         void getPlaces_withTagAndKeyword() {
             // given
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자", false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "전체", "피자", false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 피자").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
-            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(null, List.of(tag), "피자", false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when
@@ -287,14 +287,14 @@ class PlaceServiceTest {
             // given
             Category category = new Category("맛집");
             Tag tag = new Tag("가성비");
-            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨", false, null);
+            PlaceSearchConditions conditions = new PlaceSearchConditions(List.of("가성비"), "맛집", "치킨", false, null, null, null);
             Pageable pageable = PageRequest.of(0, 10);
             Place place1 = Place.builder().name("가성비 치킨집").build();
             Page<PlaceQueryResult> pageResult = new PageImpl<>(List.of(new PlaceQueryResult(place1, 0L)));
 
             given(tagRepository.findByNameIn(conditions.tags())).willReturn(List.of(tag));
             given(categoryRepository.findByName("맛집")).willReturn(Optional.of(category));
-            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, PlaceSortType.REVIEW_COUNT, pageable))
+            given(placeRepository.getPlacesByConditions(category, List.of(tag), "치킨", false, PlaceSortType.REVIEW_COUNT, null, null, pageable))
                     .willReturn(pageResult);
 
             // when

--- a/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/PlaceSortRepositoryTest.java
@@ -97,7 +97,7 @@ class PlaceSortRepositoryTest {
         @DisplayName("REVIEW_COUNT: 리뷰 많은 순으로 정렬한다")
         void sortByReviewCount() {
             Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
-                    null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, pageable);
+                    null, List.of(), null, false, PlaceSortType.REVIEW_COUNT, null, null, pageable);
 
             // A(3) > B(2) > C(0)
             assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");
@@ -107,7 +107,7 @@ class PlaceSortRepositoryTest {
         @DisplayName("RATING: 평균 별점 높은 순으로 정렬하고, 리뷰 없는 장소는 맨 뒤로 보낸다")
         void sortByRating() {
             Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
-                    null, List.of(), null, false, PlaceSortType.RATING, pageable);
+                    null, List.of(), null, false, PlaceSortType.RATING, null, null, pageable);
 
             // A(5) > B(3) > C(리뷰 없음 → 맨 뒤)
             assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");
@@ -117,7 +117,7 @@ class PlaceSortRepositoryTest {
         @DisplayName("VIEW_COUNT: 조회수 많은 순으로 정렬한다")
         void sortByViewCount() {
             Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
-                    null, List.of(), null, false, PlaceSortType.VIEW_COUNT, pageable);
+                    null, List.of(), null, false, PlaceSortType.VIEW_COUNT, null, null, pageable);
 
             // B(10) > C(5) > A(1)
             assertThat(names(result)).containsExactly("장소B", "장소C", "장소A");
@@ -127,7 +127,7 @@ class PlaceSortRepositoryTest {
         @DisplayName("sort가 null이면 기본값(REVIEW_COUNT)으로 정렬한다")
         void sortByNull_usesReviewCountDefault() {
             Page<PlaceQueryResult> result = placeRepository.getPlacesByConditions(
-                    null, List.of(), null, false, null, pageable);
+                    null, List.of(), null, false, null, null, null, pageable);
 
             // 기본값 = REVIEW_COUNT → A(3) > B(2) > C(0)
             assertThat(names(result)).containsExactly("장소A", "장소B", "장소C");

--- a/src/test/java/org/example/sejonglifebe/place/dto/PlaceSearchConditionsTest.java
+++ b/src/test/java/org/example/sejonglifebe/place/dto/PlaceSearchConditionsTest.java
@@ -1,0 +1,40 @@
+package org.example.sejonglifebe.place.dto;
+
+import org.example.sejonglifebe.exception.ErrorCode;
+import org.example.sejonglifebe.exception.SejongLifeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class PlaceSearchConditionsTest {
+
+    @Test
+    @DisplayName("DISTANCE 정렬인데 좌표(lat/lng)가 없으면 예외를 던진다")
+    void distanceSort_withoutCoordinates_throws() {
+        assertThatThrownBy(() ->
+                new PlaceSearchConditions(List.of(), "전체", null, false, PlaceSortType.DISTANCE, null, null))
+                .isInstanceOf(SejongLifeException.class)
+                .hasMessage(ErrorCode.DISTANCE_SORT_REQUIRES_LOCATION.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("DISTANCE 정렬이고 좌표가 있으면 정상 생성된다")
+    void distanceSort_withCoordinates_ok() {
+        assertThatCode(() ->
+                new PlaceSearchConditions(List.of(), "전체", null, false, PlaceSortType.DISTANCE, 37.55, 127.07))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DISTANCE가 아니면 좌표가 없어도 정상 생성된다")
+    void nonDistanceSort_withoutCoordinates_ok() {
+        assertThatCode(() ->
+                new PlaceSearchConditions(List.of(), "전체", null, false, PlaceSortType.REVIEW_COUNT, null, null))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## 🔀 무엇을 위한 PR인가요?

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

---

## 🔗 관련 이슈

- Closes #195 

---

## 📝 주요 변경 내용

- 장소 목록 조회에 거리순 정렬(sortType=DISTANCE)을 추가했습니다.
- 사용자 위치(latitude, longitude)를 기준으로 가까운 순으로 정렬합니다.
- 좌표 없이 거리순을 요청하면 400으로 에러를 던집니다.
---

## 🛠️ 작업 상세 내역

- PlaceSortType에 DISTANCE를 추가하고 PlaceSearchConditions에 latitude,longitude 필드와 검증을 추가했습니다.
- 거리 계산은 MySQL의 ST_Distance_Sphere로 처리했습니다. (QueryDSL numberTemplate 사용)
- 좌표가 동점일 때 순서가 흔들리지 않도록 기존 id 2차 정렬키를 그대로 사용했습니다.
- 거리순은 DB 종속 기능이라 통합 테스트는 실제 MySQL 기준으로 작성했습니다.

---

## 🧐 어떤 부분에 리뷰어가 집중하면 좋을까요?

- ST_Distance_Sphere는 MySQL 전용 함수라 H2에서는 동작하지 않습니다. 로컬 테스트 시 MYSQL 띄워야 합니다!

---